### PR TITLE
feat(identity): Users + Blocks + Reports 기능 구현

### DIFF
--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/command/CreateBlockCommandHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/command/CreateBlockCommandHandler.kt
@@ -1,0 +1,19 @@
+package com.mungcle.identity.application.command
+
+import com.mungcle.identity.domain.model.Block
+import com.mungcle.identity.domain.port.`in`.CreateBlockUseCase
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CreateBlockCommandHandler(
+    private val blockRepository: BlockRepositoryPort,
+) : CreateBlockUseCase {
+
+    @Transactional
+    override suspend fun execute(blockerId: Long, blockedId: Long) {
+        if (blockRepository.existsByBlockerAndBlocked(blockerId, blockedId)) return
+        blockRepository.save(Block(blockerId = blockerId, blockedId = blockedId))
+    }
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/command/CreateReportCommandHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/command/CreateReportCommandHandler.kt
@@ -1,0 +1,34 @@
+package com.mungcle.identity.application.command
+
+import com.mungcle.identity.domain.exception.UserNotFoundException
+import com.mungcle.identity.domain.model.Report
+import com.mungcle.identity.domain.port.`in`.CreateReportUseCase
+import com.mungcle.identity.domain.port.out.ReportRepositoryPort
+import com.mungcle.identity.domain.port.out.UserRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private const val FLAG_THRESHOLD = 3L
+
+@Service
+class CreateReportCommandHandler(
+    private val reportRepository: ReportRepositoryPort,
+    private val userRepository: UserRepositoryPort,
+) : CreateReportUseCase {
+
+    @Transactional
+    override suspend fun execute(reporterId: Long, reportedId: Long, reason: String) {
+        reportRepository.save(
+            Report(reporterId = reporterId, reportedId = reportedId, reason = reason)
+        )
+
+        val count = reportRepository.countByReportedId(reportedId)
+        if (count >= FLAG_THRESHOLD) {
+            val reported = userRepository.findById(reportedId)
+                ?: throw UserNotFoundException(reportedId)
+            if (!reported.flaggedForReview) {
+                userRepository.save(reported.copy(flaggedForReview = true))
+            }
+        }
+    }
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/command/DeleteBlockCommandHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/command/DeleteBlockCommandHandler.kt
@@ -1,0 +1,17 @@
+package com.mungcle.identity.application.command
+
+import com.mungcle.identity.domain.port.`in`.DeleteBlockUseCase
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DeleteBlockCommandHandler(
+    private val blockRepository: BlockRepositoryPort,
+) : DeleteBlockUseCase {
+
+    @Transactional
+    override suspend fun execute(blockerId: Long, blockedId: Long) {
+        blockRepository.delete(blockerId, blockedId)
+    }
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/command/DeleteUserCommandHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/command/DeleteUserCommandHandler.kt
@@ -1,0 +1,20 @@
+package com.mungcle.identity.application.command
+
+import com.mungcle.identity.domain.exception.UserNotFoundException
+import com.mungcle.identity.domain.port.`in`.DeleteUserUseCase
+import com.mungcle.identity.domain.port.out.UserRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DeleteUserCommandHandler(
+    private val userRepository: UserRepositoryPort,
+) : DeleteUserUseCase {
+
+    @Transactional
+    override suspend fun execute(userId: Long) {
+        val user = userRepository.findById(userId)
+            ?: throw UserNotFoundException(userId)
+        userRepository.save(user.softDelete())
+    }
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/command/UpdateUserCommandHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/command/UpdateUserCommandHandler.kt
@@ -1,0 +1,30 @@
+package com.mungcle.identity.application.command
+
+import com.mungcle.identity.domain.exception.UserNotFoundException
+import com.mungcle.identity.domain.model.User
+import com.mungcle.identity.domain.model.User.Companion.validateNickname
+import com.mungcle.identity.domain.port.`in`.UpdateUserUseCase
+import com.mungcle.identity.domain.port.out.UserRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UpdateUserCommandHandler(
+    private val userRepository: UserRepositoryPort,
+) : UpdateUserUseCase {
+
+    @Transactional
+    override suspend fun execute(command: UpdateUserUseCase.Command): User {
+        val user = userRepository.findById(command.userId)
+            ?: throw UserNotFoundException(command.userId)
+
+        command.nickname?.let { validateNickname(it) }
+
+        val updated = user.copy(
+            nickname = command.nickname ?: user.nickname,
+            neighborhood = command.neighborhood ?: user.neighborhood,
+            profilePhotoPath = command.profilePhotoPath ?: user.profilePhotoPath,
+        )
+        return userRepository.save(updated)
+    }
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/query/GetBlockedUserIdsQueryHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/query/GetBlockedUserIdsQueryHandler.kt
@@ -1,0 +1,14 @@
+package com.mungcle.identity.application.query
+
+import com.mungcle.identity.domain.port.`in`.GetBlockedUserIdsUseCase
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetBlockedUserIdsQueryHandler(
+    private val blockRepository: BlockRepositoryPort,
+) : GetBlockedUserIdsUseCase {
+
+    override suspend fun execute(userId: Long): List<Long> =
+        blockRepository.findBlockedUserIds(userId)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/query/GetUserQueryHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/query/GetUserQueryHandler.kt
@@ -1,0 +1,16 @@
+package com.mungcle.identity.application.query
+
+import com.mungcle.identity.domain.exception.UserNotFoundException
+import com.mungcle.identity.domain.model.User
+import com.mungcle.identity.domain.port.`in`.GetUserUseCase
+import com.mungcle.identity.domain.port.out.UserRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetUserQueryHandler(
+    private val userRepository: UserRepositoryPort,
+) : GetUserUseCase {
+
+    override suspend fun execute(userId: Long): User =
+        userRepository.findById(userId) ?: throw UserNotFoundException(userId)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/query/GetUsersByIdsQueryHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/query/GetUsersByIdsQueryHandler.kt
@@ -1,0 +1,15 @@
+package com.mungcle.identity.application.query
+
+import com.mungcle.identity.domain.model.User
+import com.mungcle.identity.domain.port.`in`.GetUsersByIdsUseCase
+import com.mungcle.identity.domain.port.out.UserRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetUsersByIdsQueryHandler(
+    private val userRepository: UserRepositoryPort,
+) : GetUsersByIdsUseCase {
+
+    override suspend fun execute(userIds: List<Long>): List<User> =
+        userRepository.findByIds(userIds)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/query/IsBlockedQueryHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/query/IsBlockedQueryHandler.kt
@@ -1,0 +1,14 @@
+package com.mungcle.identity.application.query
+
+import com.mungcle.identity.domain.port.`in`.IsBlockedUseCase
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class IsBlockedQueryHandler(
+    private val blockRepository: BlockRepositoryPort,
+) : IsBlockedUseCase {
+
+    override suspend fun execute(userIdA: Long, userIdB: Long): Boolean =
+        blockRepository.isBlocked(userIdA, userIdB)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/application/query/ListBlocksQueryHandler.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/application/query/ListBlocksQueryHandler.kt
@@ -1,0 +1,15 @@
+package com.mungcle.identity.application.query
+
+import com.mungcle.identity.domain.model.Block
+import com.mungcle.identity.domain.port.`in`.ListBlocksUseCase
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class ListBlocksQueryHandler(
+    private val blockRepository: BlockRepositoryPort,
+) : ListBlocksUseCase {
+
+    override suspend fun execute(userId: Long): List<Block> =
+        blockRepository.findByBlockerId(userId)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/config/IdentityConfig.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/config/IdentityConfig.kt
@@ -1,10 +1,14 @@
 package com.mungcle.identity.config
 
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
 import com.mungcle.identity.domain.port.out.JwtPort
 import com.mungcle.identity.domain.port.out.KakaoApiPort
 import com.mungcle.identity.domain.port.out.PasswordPort
+import com.mungcle.identity.domain.port.out.ReportRepositoryPort
 import com.mungcle.identity.domain.port.out.UserRepositoryPort
 import com.mungcle.identity.infrastructure.external.KakaoApiAdapter
+import com.mungcle.identity.infrastructure.persistence.BlockRepositoryAdapter
+import com.mungcle.identity.infrastructure.persistence.ReportRepositoryAdapter
 import com.mungcle.identity.infrastructure.persistence.UserRepositoryAdapter
 import com.mungcle.identity.infrastructure.security.BcryptPasswordAdapter
 import com.mungcle.identity.infrastructure.security.JwtAdapter
@@ -17,6 +21,12 @@ class IdentityConfig {
 
     @Bean
     fun userRepositoryPort(adapter: UserRepositoryAdapter): UserRepositoryPort = adapter
+
+    @Bean
+    fun blockRepositoryPort(adapter: BlockRepositoryAdapter): BlockRepositoryPort = adapter
+
+    @Bean
+    fun reportRepositoryPort(adapter: ReportRepositoryAdapter): ReportRepositoryPort = adapter
 
     @Bean
     fun jwtPort(adapter: JwtAdapter): JwtPort = adapter

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/exception/IdentityExceptions.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/exception/IdentityExceptions.kt
@@ -13,3 +13,9 @@ class InvalidNicknameException(nickname: String) :
 
 class UserNotFoundException(id: Long) :
     IdentityException("사용자를 찾을 수 없습니다: $id")
+
+class BlockSelfException :
+    IdentityException("자기 자신을 차단할 수 없습니다")
+
+class ReportSelfException :
+    IdentityException("자기 자신을 신고할 수 없습니다")

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/exception/IdentityExceptions.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/exception/IdentityExceptions.kt
@@ -19,3 +19,6 @@ class BlockSelfException :
 
 class ReportSelfException :
     IdentityException("자기 자신을 신고할 수 없습니다")
+
+class InvalidReportReasonException :
+    IdentityException("신고 사유는 1~500자여야 합니다")

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/Block.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/Block.kt
@@ -1,0 +1,16 @@
+package com.mungcle.identity.domain.model
+
+import java.time.Instant
+
+/**
+ * 차단 도메인 모델.
+ * 순수 Kotlin 객체 — 프레임워크 의존성 없음.
+ */
+data class Block(
+    val id: Long = 0,
+    val blockerId: Long,
+    val blockedId: Long,
+    val createdAt: Instant = Instant.now()
+) {
+    init { require(blockerId != blockedId) { "자기 자신을 차단할 수 없습니다" } }
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/Block.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/Block.kt
@@ -1,5 +1,6 @@
 package com.mungcle.identity.domain.model
 
+import com.mungcle.identity.domain.exception.BlockSelfException
 import java.time.Instant
 
 /**
@@ -12,5 +13,5 @@ data class Block(
     val blockedId: Long,
     val createdAt: Instant = Instant.now()
 ) {
-    init { require(blockerId != blockedId) { "자기 자신을 차단할 수 없습니다" } }
+    init { if (blockerId == blockedId) throw BlockSelfException() }
 }

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/Report.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/Report.kt
@@ -1,0 +1,20 @@
+package com.mungcle.identity.domain.model
+
+import java.time.Instant
+
+/**
+ * 신고 도메인 모델.
+ * 순수 Kotlin 객체 — 프레임워크 의존성 없음.
+ */
+data class Report(
+    val id: Long = 0,
+    val reporterId: Long,
+    val reportedId: Long,
+    val reason: String,
+    val createdAt: Instant = Instant.now()
+) {
+    init {
+        require(reporterId != reportedId) { "자기 자신을 신고할 수 없습니다" }
+        require(reason.length in 1..500) { "신고 사유는 1~500자여야 합니다" }
+    }
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/Report.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/Report.kt
@@ -1,5 +1,7 @@
 package com.mungcle.identity.domain.model
 
+import com.mungcle.identity.domain.exception.InvalidReportReasonException
+import com.mungcle.identity.domain.exception.ReportSelfException
 import java.time.Instant
 
 /**
@@ -14,7 +16,7 @@ data class Report(
     val createdAt: Instant = Instant.now()
 ) {
     init {
-        require(reporterId != reportedId) { "자기 자신을 신고할 수 없습니다" }
-        require(reason.length in 1..500) { "신고 사유는 1~500자여야 합니다" }
+        if (reporterId == reportedId) throw ReportSelfException()
+        if (reason.length !in 1..500) throw InvalidReportReasonException()
     }
 }

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/User.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/model/User.kt
@@ -14,8 +14,20 @@ data class User(
     val passwordHash: String? = null,
     val nickname: String,
     val pushToken: String? = null,
+    val neighborhood: String? = null,
+    val profilePhotoPath: String? = null,
+    val flaggedForReview: Boolean = false,
+    val deletedAt: Instant? = null,
     val createdAt: Instant = Instant.now()
 ) {
+    /** 회원 탈퇴 소프트 삭제 — 개인정보 익명화 */
+    fun softDelete(): User = copy(
+        email = "deleted_${id}@",
+        kakaoId = null,
+        nickname = "탈퇴한 사용자",
+        deletedAt = Instant.now(),
+    )
+
     companion object {
         private val NICKNAME_REGEX = Regex("^[가-힣a-zA-Z0-9_]{2,16}$")
 

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/CreateBlockUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/CreateBlockUseCase.kt
@@ -1,0 +1,9 @@
+package com.mungcle.identity.domain.port.`in`
+
+/**
+ * 차단 생성 유스케이스 포트.
+ */
+interface CreateBlockUseCase {
+    /** blockerId가 blockedId를 차단. 이미 차단된 경우 멱등 처리 */
+    suspend fun execute(blockerId: Long, blockedId: Long)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/CreateReportUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/CreateReportUseCase.kt
@@ -1,0 +1,9 @@
+package com.mungcle.identity.domain.port.`in`
+
+/**
+ * 신고 생성 유스케이스 포트.
+ */
+interface CreateReportUseCase {
+    /** reporterId가 reportedId를 reason 사유로 신고 */
+    suspend fun execute(reporterId: Long, reportedId: Long, reason: String)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/DeleteBlockUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/DeleteBlockUseCase.kt
@@ -1,0 +1,9 @@
+package com.mungcle.identity.domain.port.`in`
+
+/**
+ * 차단 해제 유스케이스 포트.
+ */
+interface DeleteBlockUseCase {
+    /** blockerId와 blockedId 간의 차단 해제 */
+    suspend fun execute(blockerId: Long, blockedId: Long)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/DeleteUserUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/DeleteUserUseCase.kt
@@ -1,0 +1,9 @@
+package com.mungcle.identity.domain.port.`in`
+
+/**
+ * 사용자 탈퇴(소프트 삭제) 유스케이스 포트.
+ */
+interface DeleteUserUseCase {
+    /** userId에 해당하는 사용자를 익명화하여 소프트 삭제 */
+    suspend fun execute(userId: Long)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/GetBlockedUserIdsUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/GetBlockedUserIdsUseCase.kt
@@ -1,0 +1,9 @@
+package com.mungcle.identity.domain.port.`in`
+
+/**
+ * 양방향 차단된 사용자 ID 목록 조회 유스케이스 포트.
+ */
+interface GetBlockedUserIdsUseCase {
+    /** userId가 차단했거나 차단당한 사용자 ID 목록 반환 (양방향) */
+    suspend fun execute(userId: Long): List<Long>
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/GetUserUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/GetUserUseCase.kt
@@ -1,0 +1,11 @@
+package com.mungcle.identity.domain.port.`in`
+
+import com.mungcle.identity.domain.model.User
+
+/**
+ * 단일 사용자 조회 유스케이스 포트.
+ */
+interface GetUserUseCase {
+    /** userId에 해당하는 사용자 반환. 없으면 [com.mungcle.identity.domain.exception.UserNotFoundException] */
+    suspend fun execute(userId: Long): User
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/GetUsersByIdsUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/GetUsersByIdsUseCase.kt
@@ -1,0 +1,11 @@
+package com.mungcle.identity.domain.port.`in`
+
+import com.mungcle.identity.domain.model.User
+
+/**
+ * 여러 사용자 일괄 조회 유스케이스 포트.
+ */
+interface GetUsersByIdsUseCase {
+    /** 주어진 ID 목록에 해당하는 사용자 목록 반환. 존재하지 않는 ID는 무시 */
+    suspend fun execute(userIds: List<Long>): List<User>
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/IsBlockedUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/IsBlockedUseCase.kt
@@ -1,0 +1,9 @@
+package com.mungcle.identity.domain.port.`in`
+
+/**
+ * 차단 여부 확인 유스케이스 포트.
+ */
+interface IsBlockedUseCase {
+    /** userIdA와 userIdB 사이에 양방향 차단이 있으면 true */
+    suspend fun execute(userIdA: Long, userIdB: Long): Boolean
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/ListBlocksUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/ListBlocksUseCase.kt
@@ -1,0 +1,11 @@
+package com.mungcle.identity.domain.port.`in`
+
+import com.mungcle.identity.domain.model.Block
+
+/**
+ * 차단 목록 조회 유스케이스 포트.
+ */
+interface ListBlocksUseCase {
+    /** userId가 차단한 목록 반환 */
+    suspend fun execute(userId: Long): List<Block>
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/UpdateUserUseCase.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/in/UpdateUserUseCase.kt
@@ -1,0 +1,19 @@
+package com.mungcle.identity.domain.port.`in`
+
+import com.mungcle.identity.domain.model.User
+
+/**
+ * 사용자 정보 수정 유스케이스 포트.
+ */
+interface UpdateUserUseCase {
+    /** null 필드는 변경하지 않음 (부분 업데이트) */
+    data class Command(
+        val userId: Long,
+        val nickname: String? = null,
+        val neighborhood: String? = null,
+        val profilePhotoPath: String? = null,
+    )
+
+    /** Command에 따라 사용자 정보를 업데이트하고 갱신된 사용자 반환 */
+    suspend fun execute(command: Command): User
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/out/BlockRepositoryPort.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/out/BlockRepositoryPort.kt
@@ -1,0 +1,26 @@
+package com.mungcle.identity.domain.port.out
+
+import com.mungcle.identity.domain.model.Block
+
+/**
+ * 차단 저장소 아웃바운드 포트.
+ */
+interface BlockRepositoryPort {
+    /** 차단 저장 */
+    fun save(block: Block): Block
+
+    /** 차단 삭제 */
+    fun delete(blockerId: Long, blockedId: Long)
+
+    /** 차단자 ID로 차단 목록 조회 */
+    fun findByBlockerId(blockerId: Long): List<Block>
+
+    /** 양방향 차단된 사용자 ID 목록 조회 */
+    fun findBlockedUserIds(userId: Long): List<Long>
+
+    /** 양방향 차단 여부 확인 */
+    fun isBlocked(userIdA: Long, userIdB: Long): Boolean
+
+    /** 특정 방향의 차단 존재 여부 확인 */
+    fun existsByBlockerAndBlocked(blockerId: Long, blockedId: Long): Boolean
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/out/ReportRepositoryPort.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/out/ReportRepositoryPort.kt
@@ -1,0 +1,14 @@
+package com.mungcle.identity.domain.port.out
+
+import com.mungcle.identity.domain.model.Report
+
+/**
+ * 신고 저장소 아웃바운드 포트.
+ */
+interface ReportRepositoryPort {
+    /** 신고 저장 */
+    fun save(report: Report): Report
+
+    /** 피신고자 ID로 신고 건수 조회 */
+    fun countByReportedId(reportedId: Long): Long
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/out/UserRepositoryPort.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/domain/port/out/UserRepositoryPort.kt
@@ -17,4 +17,7 @@ interface UserRepositoryPort {
 
     /** 카카오 ID로 사용자 조회 */
     suspend fun findByKakaoId(kakaoId: String): User?
+
+    /** 여러 ID로 사용자 목록 조회 */
+    suspend fun findByIds(ids: List<Long>): List<User>
 }

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
@@ -1,8 +1,10 @@
 package com.mungcle.identity.infrastructure.grpc.server
 
+import com.mungcle.identity.domain.exception.BlockSelfException
 import com.mungcle.identity.domain.exception.EmailTakenException
 import com.mungcle.identity.domain.exception.InvalidCredentialsException
 import com.mungcle.identity.domain.exception.InvalidNicknameException
+import com.mungcle.identity.domain.exception.ReportSelfException
 import com.mungcle.identity.domain.exception.UserNotFoundException
 import io.grpc.ForwardingServerCallListener
 import io.grpc.Metadata
@@ -42,6 +44,8 @@ class GrpcExceptionInterceptor : ServerInterceptor {
             is InvalidCredentialsException -> Status.UNAUTHENTICATED.withDescription(e.message)
             is UserNotFoundException -> Status.NOT_FOUND.withDescription(e.message)
             is InvalidNicknameException -> Status.INVALID_ARGUMENT.withDescription(e.message)
+            is BlockSelfException -> Status.INVALID_ARGUMENT.withDescription(e.message)
+            is ReportSelfException -> Status.INVALID_ARGUMENT.withDescription(e.message)
             else -> Status.INTERNAL.withDescription(e.message)
         }
         call.close(status, headers)

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
@@ -4,6 +4,7 @@ import com.mungcle.identity.domain.exception.BlockSelfException
 import com.mungcle.identity.domain.exception.EmailTakenException
 import com.mungcle.identity.domain.exception.InvalidCredentialsException
 import com.mungcle.identity.domain.exception.InvalidNicknameException
+import com.mungcle.identity.domain.exception.InvalidReportReasonException
 import com.mungcle.identity.domain.exception.ReportSelfException
 import com.mungcle.identity.domain.exception.UserNotFoundException
 import io.grpc.ForwardingServerCallListener
@@ -46,6 +47,7 @@ class GrpcExceptionInterceptor : ServerInterceptor {
             is InvalidNicknameException -> Status.INVALID_ARGUMENT.withDescription(e.message)
             is BlockSelfException -> Status.INVALID_ARGUMENT.withDescription(e.message)
             is ReportSelfException -> Status.INVALID_ARGUMENT.withDescription(e.message)
+            is InvalidReportReasonException -> Status.INVALID_ARGUMENT.withDescription(e.message)
             else -> Status.INTERNAL.withDescription(e.message)
         }
         call.close(status, headers)

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/IdentityAuthGrpcService.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/IdentityAuthGrpcService.kt
@@ -1,9 +1,19 @@
 package com.mungcle.identity.infrastructure.grpc.server
 
 import com.mungcle.identity.domain.port.`in`.AuthenticateKakaoUseCase
+import com.mungcle.identity.domain.port.`in`.CreateBlockUseCase
+import com.mungcle.identity.domain.port.`in`.CreateReportUseCase
+import com.mungcle.identity.domain.port.`in`.DeleteBlockUseCase
+import com.mungcle.identity.domain.port.`in`.DeleteUserUseCase
+import com.mungcle.identity.domain.port.`in`.GetBlockedUserIdsUseCase
+import com.mungcle.identity.domain.port.`in`.GetUserUseCase
+import com.mungcle.identity.domain.port.`in`.GetUsersByIdsUseCase
+import com.mungcle.identity.domain.port.`in`.IsBlockedUseCase
+import com.mungcle.identity.domain.port.`in`.ListBlocksUseCase
 import com.mungcle.identity.domain.port.`in`.LoginEmailUseCase
 import com.mungcle.identity.domain.port.`in`.RegisterEmailUseCase
 import com.mungcle.identity.domain.port.`in`.UpdatePushTokenUseCase
+import com.mungcle.identity.domain.port.`in`.UpdateUserUseCase
 import com.mungcle.identity.domain.port.`in`.ValidateTokenUseCase
 import com.mungcle.proto.identity.v1.AuthResponse
 import com.mungcle.proto.identity.v1.AuthenticateKakaoRequest
@@ -35,6 +45,15 @@ import com.mungcle.proto.identity.v1.UserInfo
 import com.mungcle.proto.identity.v1.ValidateTokenRequest
 import com.mungcle.proto.identity.v1.ValidateTokenResponse
 import com.mungcle.proto.identity.v1.authResponse
+import com.mungcle.proto.identity.v1.blockInfo
+import com.mungcle.proto.identity.v1.createBlockResponse
+import com.mungcle.proto.identity.v1.createReportResponse
+import com.mungcle.proto.identity.v1.deleteBlockResponse
+import com.mungcle.proto.identity.v1.deleteUserResponse
+import com.mungcle.proto.identity.v1.getBlockedUserIdsResponse
+import com.mungcle.proto.identity.v1.getUsersByIdsResponse
+import com.mungcle.proto.identity.v1.isBlockedResponse
+import com.mungcle.proto.identity.v1.listBlocksResponse
 import com.mungcle.proto.identity.v1.updatePushTokenResponse
 import com.mungcle.proto.identity.v1.userInfo
 import com.mungcle.proto.identity.v1.validateTokenResponse
@@ -50,6 +69,16 @@ class IdentityAuthGrpcService(
     private val loginEmailUseCase: LoginEmailUseCase,
     private val validateTokenUseCase: ValidateTokenUseCase,
     private val updatePushTokenUseCase: UpdatePushTokenUseCase,
+    private val getUserUseCase: GetUserUseCase,
+    private val getUsersByIdsUseCase: GetUsersByIdsUseCase,
+    private val updateUserUseCase: UpdateUserUseCase,
+    private val deleteUserUseCase: DeleteUserUseCase,
+    private val createBlockUseCase: CreateBlockUseCase,
+    private val deleteBlockUseCase: DeleteBlockUseCase,
+    private val listBlocksUseCase: ListBlocksUseCase,
+    private val getBlockedUserIdsUseCase: GetBlockedUserIdsUseCase,
+    private val isBlockedUseCase: IsBlockedUseCase,
+    private val createReportUseCase: CreateReportUseCase,
 ) : IdentityServiceGrpcKt.IdentityServiceCoroutineImplBase() {
 
     override suspend fun authenticateKakao(request: AuthenticateKakaoRequest): AuthResponse {
@@ -100,36 +129,91 @@ class IdentityAuthGrpcService(
         return updatePushTokenResponse { }
     }
 
-    // 나머지 RPC는 task 02에서 구현 예정
-    override suspend fun getUser(request: GetUserRequest): UserInfo =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun getUser(request: GetUserRequest): UserInfo {
+        val user = getUserUseCase.execute(request.userId)
+        return userInfo {
+            id = user.id
+            nickname = user.nickname
+            neighborhood = user.neighborhood ?: ""
+            profilePhotoUrl = user.profilePhotoPath ?: ""
+        }
+    }
 
-    override suspend fun getUsersByIds(request: GetUsersByIdsRequest): GetUsersByIdsResponse =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun getUsersByIds(request: GetUsersByIdsRequest): GetUsersByIdsResponse {
+        val users = getUsersByIdsUseCase.execute(request.userIdsList)
+        return getUsersByIdsResponse {
+            this.users += users.map { u ->
+                userInfo {
+                    id = u.id
+                    nickname = u.nickname
+                    neighborhood = u.neighborhood ?: ""
+                    profilePhotoUrl = u.profilePhotoPath ?: ""
+                }
+            }
+        }
+    }
 
-    override suspend fun updateUser(request: UpdateUserRequest): UserInfo =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun updateUser(request: UpdateUserRequest): UserInfo {
+        val user = updateUserUseCase.execute(
+            UpdateUserUseCase.Command(
+                userId = request.userId,
+                nickname = if (request.hasNickname()) request.nickname else null,
+                neighborhood = if (request.hasNeighborhood()) request.neighborhood else null,
+                profilePhotoPath = if (request.hasProfilePhotoPath()) request.profilePhotoPath else null,
+            )
+        )
+        return userInfo {
+            id = user.id
+            nickname = user.nickname
+            neighborhood = user.neighborhood ?: ""
+            profilePhotoUrl = user.profilePhotoPath ?: ""
+        }
+    }
 
-    override suspend fun deleteUser(request: DeleteUserRequest): DeleteUserResponse =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun deleteUser(request: DeleteUserRequest): DeleteUserResponse {
+        deleteUserUseCase.execute(request.userId)
+        return deleteUserResponse { }
+    }
 
-    override suspend fun createBlock(request: CreateBlockRequest): CreateBlockResponse =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun createBlock(request: CreateBlockRequest): CreateBlockResponse {
+        createBlockUseCase.execute(request.blockerId, request.blockedId)
+        return createBlockResponse { }
+    }
 
-    override suspend fun deleteBlock(request: DeleteBlockRequest): DeleteBlockResponse =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun deleteBlock(request: DeleteBlockRequest): DeleteBlockResponse {
+        deleteBlockUseCase.execute(request.blockerId, request.blockedId)
+        return deleteBlockResponse { }
+    }
 
-    override suspend fun listBlocks(request: ListBlocksRequest): ListBlocksResponse =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun listBlocks(request: ListBlocksRequest): ListBlocksResponse {
+        val blocks = listBlocksUseCase.execute(request.userId)
+        return listBlocksResponse {
+            this.blocks += blocks.map { b ->
+                blockInfo {
+                    blockedUserId = b.blockedId
+                    blockedNickname = ""
+                    createdAt = b.createdAt.epochSecond
+                }
+            }
+        }
+    }
 
-    override suspend fun getBlockedUserIds(request: GetBlockedUserIdsRequest): GetBlockedUserIdsResponse =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun getBlockedUserIds(request: GetBlockedUserIdsRequest): GetBlockedUserIdsResponse {
+        val ids = getBlockedUserIdsUseCase.execute(request.userId)
+        return getBlockedUserIdsResponse {
+            this.blockedUserIds += ids
+        }
+    }
 
-    override suspend fun isBlocked(request: IsBlockedRequest): IsBlockedResponse =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun isBlocked(request: IsBlockedRequest): IsBlockedResponse {
+        val blocked = isBlockedUseCase.execute(request.userIdA, request.userIdB)
+        return isBlockedResponse { this.blocked = blocked }
+    }
 
-    override suspend fun createReport(request: CreateReportRequest): CreateReportResponse =
-        throw StatusException(Status.UNIMPLEMENTED)
+    override suspend fun createReport(request: CreateReportRequest): CreateReportResponse {
+        createReportUseCase.execute(request.reporterId, request.reportedId, request.reason)
+        return createReportResponse { }
+    }
 
     private fun AuthResult.toAuthResponse(): AuthResponse = authResponse {
         accessToken = this@toAuthResponse.accessToken

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/IdentityAuthGrpcService.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/IdentityAuthGrpcService.kt
@@ -187,11 +187,17 @@ class IdentityAuthGrpcService(
 
     override suspend fun listBlocks(request: ListBlocksRequest): ListBlocksResponse {
         val blocks = listBlocksUseCase.execute(request.userId)
+        val blockedUserIds = blocks.map { it.blockedId }
+        val nicknameMap = if (blockedUserIds.isNotEmpty()) {
+            getUsersByIdsUseCase.execute(blockedUserIds).associate { it.id to it.nickname }
+        } else {
+            emptyMap()
+        }
         return listBlocksResponse {
             this.blocks += blocks.map { b ->
                 blockInfo {
                     blockedUserId = b.blockedId
-                    blockedNickname = ""
+                    blockedNickname = nicknameMap[b.blockedId] ?: ""
                     createdAt = b.createdAt.epochSecond
                 }
             }

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/BlockEntity.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/BlockEntity.kt
@@ -1,0 +1,26 @@
+package com.mungcle.identity.infrastructure.persistence
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "blocks", schema = "identity")
+open class BlockEntity(
+    @Id
+    @Tsid
+    @Column(name = "id", nullable = false)
+    open var id: Long = 0,
+
+    @Column(name = "blocker_id", nullable = false)
+    open var blockerId: Long = 0,
+
+    @Column(name = "blocked_id", nullable = false)
+    open var blockedId: Long = 0,
+
+    @Column(name = "created_at", nullable = false)
+    open var createdAt: Instant = Instant.now(),
+)

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/BlockMapper.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/BlockMapper.kt
@@ -1,0 +1,19 @@
+package com.mungcle.identity.infrastructure.persistence
+
+import com.mungcle.identity.domain.model.Block
+
+object BlockMapper {
+    fun toDomain(entity: BlockEntity): Block = Block(
+        id = entity.id,
+        blockerId = entity.blockerId,
+        blockedId = entity.blockedId,
+        createdAt = entity.createdAt,
+    )
+
+    fun toEntity(domain: Block): BlockEntity = BlockEntity(
+        id = domain.id,
+        blockerId = domain.blockerId,
+        blockedId = domain.blockedId,
+        createdAt = domain.createdAt,
+    )
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/BlockRepositoryAdapter.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/BlockRepositoryAdapter.kt
@@ -1,0 +1,33 @@
+package com.mungcle.identity.infrastructure.persistence
+
+import com.mungcle.identity.domain.model.Block
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class BlockRepositoryAdapter(
+    private val springDataRepository: BlockSpringDataRepository,
+) : BlockRepositoryPort {
+
+    override fun save(block: Block): Block {
+        val entity = BlockMapper.toEntity(block)
+        val saved = springDataRepository.save(entity)
+        return BlockMapper.toDomain(saved)
+    }
+
+    override fun delete(blockerId: Long, blockedId: Long) {
+        springDataRepository.deleteByBlockerIdAndBlockedId(blockerId, blockedId)
+    }
+
+    override fun findByBlockerId(blockerId: Long): List<Block> =
+        springDataRepository.findByBlockerId(blockerId).map(BlockMapper::toDomain)
+
+    override fun findBlockedUserIds(userId: Long): List<Long> =
+        springDataRepository.findBlockedUserIds(userId)
+
+    override fun isBlocked(userIdA: Long, userIdB: Long): Boolean =
+        springDataRepository.isBlocked(userIdA, userIdB)
+
+    override fun existsByBlockerAndBlocked(blockerId: Long, blockedId: Long): Boolean =
+        springDataRepository.existsByBlockerIdAndBlockedId(blockerId, blockedId)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/BlockSpringDataRepository.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/BlockSpringDataRepository.kt
@@ -1,0 +1,25 @@
+package com.mungcle.identity.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface BlockSpringDataRepository : JpaRepository<BlockEntity, Long> {
+    fun findByBlockerId(blockerId: Long): List<BlockEntity>
+
+    @Query(
+        "SELECT DISTINCT CASE WHEN b.blockerId = :userId THEN b.blockedId ELSE b.blockerId END " +
+            "FROM BlockEntity b WHERE b.blockerId = :userId OR b.blockedId = :userId"
+    )
+    fun findBlockedUserIds(userId: Long): List<Long>
+
+    fun existsByBlockerIdAndBlockedId(blockerId: Long, blockedId: Long): Boolean
+
+    fun deleteByBlockerIdAndBlockedId(blockerId: Long, blockedId: Long)
+
+    @Query(
+        "SELECT COUNT(b) > 0 FROM BlockEntity b WHERE " +
+            "(b.blockerId = :userIdA AND b.blockedId = :userIdB) OR " +
+            "(b.blockerId = :userIdB AND b.blockedId = :userIdA)"
+    )
+    fun isBlocked(userIdA: Long, userIdB: Long): Boolean
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/ReportEntity.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/ReportEntity.kt
@@ -1,0 +1,29 @@
+package com.mungcle.identity.infrastructure.persistence
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "reports", schema = "identity")
+open class ReportEntity(
+    @Id
+    @Tsid
+    @Column(name = "id", nullable = false)
+    open var id: Long = 0,
+
+    @Column(name = "reporter_id", nullable = false)
+    open var reporterId: Long = 0,
+
+    @Column(name = "reported_id", nullable = false)
+    open var reportedId: Long = 0,
+
+    @Column(name = "reason", nullable = false, length = 500)
+    open var reason: String = "",
+
+    @Column(name = "created_at", nullable = false)
+    open var createdAt: Instant = Instant.now(),
+)

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/ReportMapper.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/ReportMapper.kt
@@ -1,0 +1,21 @@
+package com.mungcle.identity.infrastructure.persistence
+
+import com.mungcle.identity.domain.model.Report
+
+object ReportMapper {
+    fun toDomain(entity: ReportEntity): Report = Report(
+        id = entity.id,
+        reporterId = entity.reporterId,
+        reportedId = entity.reportedId,
+        reason = entity.reason,
+        createdAt = entity.createdAt,
+    )
+
+    fun toEntity(domain: Report): ReportEntity = ReportEntity(
+        id = domain.id,
+        reporterId = domain.reporterId,
+        reportedId = domain.reportedId,
+        reason = domain.reason,
+        createdAt = domain.createdAt,
+    )
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/ReportRepositoryAdapter.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/ReportRepositoryAdapter.kt
@@ -1,0 +1,20 @@
+package com.mungcle.identity.infrastructure.persistence
+
+import com.mungcle.identity.domain.model.Report
+import com.mungcle.identity.domain.port.out.ReportRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class ReportRepositoryAdapter(
+    private val springDataRepository: ReportSpringDataRepository,
+) : ReportRepositoryPort {
+
+    override fun save(report: Report): Report {
+        val entity = ReportMapper.toEntity(report)
+        val saved = springDataRepository.save(entity)
+        return ReportMapper.toDomain(saved)
+    }
+
+    override fun countByReportedId(reportedId: Long): Long =
+        springDataRepository.countByReportedId(reportedId)
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/ReportSpringDataRepository.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/ReportSpringDataRepository.kt
@@ -1,0 +1,7 @@
+package com.mungcle.identity.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReportSpringDataRepository : JpaRepository<ReportEntity, Long> {
+    fun countByReportedId(reportedId: Long): Long
+}

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/UserMapper.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/UserMapper.kt
@@ -10,6 +10,10 @@ object UserMapper {
         passwordHash = entity.passwordHash,
         nickname = entity.nickname,
         pushToken = entity.pushToken,
+        neighborhood = entity.neighborhood,
+        profilePhotoPath = entity.profilePhotoPath,
+        flaggedForReview = entity.flaggedForReview,
+        deletedAt = entity.deletedAt,
         createdAt = entity.createdAt,
     )
 
@@ -20,6 +24,10 @@ object UserMapper {
         passwordHash = domain.passwordHash,
         nickname = domain.nickname,
         pushToken = domain.pushToken,
+        neighborhood = domain.neighborhood,
+        profilePhotoPath = domain.profilePhotoPath,
+        flaggedForReview = domain.flaggedForReview,
+        deletedAt = domain.deletedAt,
         createdAt = domain.createdAt,
     )
 }

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/UserRepositoryAdapter.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/UserRepositoryAdapter.kt
@@ -23,4 +23,7 @@ class UserRepositoryAdapter(
 
     override suspend fun findByKakaoId(kakaoId: String): User? =
         springDataRepository.findByKakaoId(kakaoId).orElse(null)?.let(UserMapper::toDomain)
+
+    override suspend fun findByIds(ids: List<Long>): List<User> =
+        springDataRepository.findByIdIn(ids).map(UserMapper::toDomain)
 }

--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/UserSpringDataRepository.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/persistence/UserSpringDataRepository.kt
@@ -6,4 +6,5 @@ import java.util.Optional
 interface UserSpringDataRepository : JpaRepository<UserEntity, Long> {
     fun findByEmail(email: String): Optional<UserEntity>
     fun findByKakaoId(kakaoId: String): Optional<UserEntity>
+    fun findByIdIn(ids: List<Long>): List<UserEntity>
 }

--- a/services/identity/src/test/kotlin/com/mungcle/identity/application/command/CreateBlockCommandHandlerTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/application/command/CreateBlockCommandHandlerTest.kt
@@ -37,7 +37,7 @@ class CreateBlockCommandHandlerTest {
         every { blockRepository.existsByBlockerAndBlocked(1L, 1L) } returns false
         every { blockRepository.save(any()) } answers { firstArg() }
 
-        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+        org.junit.jupiter.api.assertThrows<com.mungcle.identity.domain.exception.BlockSelfException> {
             handler.execute(blockerId = 1L, blockedId = 1L)
         }
     }

--- a/services/identity/src/test/kotlin/com/mungcle/identity/application/command/CreateBlockCommandHandlerTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/application/command/CreateBlockCommandHandlerTest.kt
@@ -1,0 +1,44 @@
+package com.mungcle.identity.application.command
+
+import com.mungcle.identity.domain.model.Block
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class CreateBlockCommandHandlerTest {
+
+    private val blockRepository: BlockRepositoryPort = mockk()
+    private val handler = CreateBlockCommandHandler(blockRepository)
+
+    @Test
+    fun `정상 차단 저장`() = runTest {
+        every { blockRepository.existsByBlockerAndBlocked(1L, 2L) } returns false
+        every { blockRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(blockerId = 1L, blockedId = 2L)
+
+        verify { blockRepository.save(any()) }
+    }
+
+    @Test
+    fun `이미 차단된 경우 멱등 처리 — 중복 저장 없음`() = runTest {
+        every { blockRepository.existsByBlockerAndBlocked(1L, 2L) } returns true
+
+        handler.execute(blockerId = 1L, blockedId = 2L)
+
+        verify(exactly = 0) { blockRepository.save(any()) }
+    }
+
+    @Test
+    fun `자기 자신 차단 시 Block 생성에서 예외 발생`() = runTest {
+        every { blockRepository.existsByBlockerAndBlocked(1L, 1L) } returns false
+        every { blockRepository.save(any()) } answers { firstArg() }
+
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            handler.execute(blockerId = 1L, blockedId = 1L)
+        }
+    }
+}

--- a/services/identity/src/test/kotlin/com/mungcle/identity/application/command/CreateReportCommandHandlerTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/application/command/CreateReportCommandHandlerTest.kt
@@ -1,0 +1,63 @@
+package com.mungcle.identity.application.command
+
+import com.mungcle.identity.domain.model.Report
+import com.mungcle.identity.domain.model.User
+import com.mungcle.identity.domain.port.out.ReportRepositoryPort
+import com.mungcle.identity.domain.port.out.UserRepositoryPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class CreateReportCommandHandlerTest {
+
+    private val reportRepository: ReportRepositoryPort = mockk()
+    private val userRepository: UserRepositoryPort = mockk()
+    private val handler = CreateReportCommandHandler(reportRepository, userRepository)
+
+    private fun makeUser(id: Long, flagged: Boolean = false) = User(
+        id = id,
+        nickname = "user$id",
+        flaggedForReview = flagged,
+        createdAt = Instant.now(),
+    )
+
+    @Test
+    fun `정상 신고 저장`() = runTest {
+        every { reportRepository.save(any()) } answers { firstArg() }
+        every { reportRepository.countByReportedId(2L) } returns 1L
+
+        handler.execute(reporterId = 1L, reportedId = 2L, reason = "부적절한 행동")
+
+        verify { reportRepository.save(any()) }
+    }
+
+    @Test
+    fun `신고 3건 이상이면 피신고자 flaggedForReview = true`() = runTest {
+        val reported = makeUser(2L, flagged = false)
+        every { reportRepository.save(any()) } answers { firstArg() }
+        every { reportRepository.countByReportedId(2L) } returns 3L
+        coEvery { userRepository.findById(2L) } returns reported
+        coEvery { userRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(reporterId = 1L, reportedId = 2L, reason = "부적절한 행동")
+
+        coVerify { userRepository.save(match { it.flaggedForReview }) }
+    }
+
+    @Test
+    fun `이미 flagged 된 사용자는 중복 저장 없음`() = runTest {
+        val reported = makeUser(2L, flagged = true)
+        every { reportRepository.save(any()) } answers { firstArg() }
+        every { reportRepository.countByReportedId(2L) } returns 5L
+        coEvery { userRepository.findById(2L) } returns reported
+
+        handler.execute(reporterId = 1L, reportedId = 2L, reason = "또 신고")
+
+        coVerify(exactly = 0) { userRepository.save(any()) }
+    }
+}

--- a/services/identity/src/test/kotlin/com/mungcle/identity/application/command/DeleteUserCommandHandlerTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/application/command/DeleteUserCommandHandlerTest.kt
@@ -1,0 +1,86 @@
+package com.mungcle.identity.application.command
+
+import com.mungcle.identity.domain.exception.UserNotFoundException
+import com.mungcle.identity.domain.model.User
+import com.mungcle.identity.domain.port.out.UserRepositoryPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DeleteUserCommandHandlerTest {
+
+    private val userRepository: UserRepositoryPort = mockk()
+    private val handler = DeleteUserCommandHandler(userRepository)
+
+    private val user = User(
+        id = 1L,
+        email = "test@example.com",
+        kakaoId = "kakao-123",
+        nickname = "testuser",
+        createdAt = Instant.now(),
+    )
+
+    @Test
+    fun `소프트 삭제 시 이메일 익명화`() = runTest {
+        coEvery { userRepository.findById(1L) } returns user
+        coEvery { userRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(1L)
+
+        coVerify {
+            userRepository.save(match { it.email == "deleted_1@" })
+        }
+    }
+
+    @Test
+    fun `소프트 삭제 시 kakaoId null`() = runTest {
+        coEvery { userRepository.findById(1L) } returns user
+        coEvery { userRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(1L)
+
+        coVerify {
+            userRepository.save(match { it.kakaoId == null })
+        }
+    }
+
+    @Test
+    fun `소프트 삭제 시 닉네임 탈퇴한 사용자로 변경`() = runTest {
+        coEvery { userRepository.findById(1L) } returns user
+        coEvery { userRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(1L)
+
+        coVerify {
+            userRepository.save(match { it.nickname == "탈퇴한 사용자" })
+        }
+    }
+
+    @Test
+    fun `소프트 삭제 시 deletedAt 설정`() = runTest {
+        coEvery { userRepository.findById(1L) } returns user
+        coEvery { userRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(1L)
+
+        coVerify {
+            userRepository.save(match { it.deletedAt != null })
+        }
+    }
+
+    @Test
+    fun `존재하지 않는 사용자 탈퇴 시 UserNotFoundException`() = runTest {
+        coEvery { userRepository.findById(99L) } returns null
+
+        assertThrows<UserNotFoundException> {
+            handler.execute(99L)
+        }
+    }
+}

--- a/services/identity/src/test/kotlin/com/mungcle/identity/application/query/GetBlockedUserIdsQueryHandlerTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/application/query/GetBlockedUserIdsQueryHandlerTest.kt
@@ -1,0 +1,34 @@
+package com.mungcle.identity.application.query
+
+import com.mungcle.identity.domain.port.out.BlockRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetBlockedUserIdsQueryHandlerTest {
+
+    private val blockRepository: BlockRepositoryPort = mockk()
+    private val handler = GetBlockedUserIdsQueryHandler(blockRepository)
+
+    @Test
+    fun `양방향 차단된 사용자 ID 목록 반환`() = runTest {
+        // userId=1 이 2를 차단하고, 3이 1을 차단한 상황 — 양방향이므로 2, 3 반환
+        every { blockRepository.findBlockedUserIds(1L) } returns listOf(2L, 3L)
+
+        val result = handler.execute(1L)
+
+        assertEquals(listOf(2L, 3L), result)
+    }
+
+    @Test
+    fun `차단 관계 없으면 빈 목록 반환`() = runTest {
+        every { blockRepository.findBlockedUserIds(1L) } returns emptyList()
+
+        val result = handler.execute(1L)
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/services/identity/src/test/kotlin/com/mungcle/identity/domain/model/BlockTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/domain/model/BlockTest.kt
@@ -1,5 +1,6 @@
 package com.mungcle.identity.domain.model
 
+import com.mungcle.identity.domain.exception.BlockSelfException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
@@ -8,7 +9,7 @@ class BlockTest {
 
     @Test
     fun `자기 자신 차단 시 예외 발생`() {
-        assertThrows<IllegalArgumentException> {
+        assertThrows<BlockSelfException> {
             Block(blockerId = 1L, blockedId = 1L)
         }
     }

--- a/services/identity/src/test/kotlin/com/mungcle/identity/domain/model/BlockTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/domain/model/BlockTest.kt
@@ -1,0 +1,22 @@
+package com.mungcle.identity.domain.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class BlockTest {
+
+    @Test
+    fun `자기 자신 차단 시 예외 발생`() {
+        assertThrows<IllegalArgumentException> {
+            Block(blockerId = 1L, blockedId = 1L)
+        }
+    }
+
+    @Test
+    fun `서로 다른 사용자 차단 성공`() {
+        val block = Block(blockerId = 1L, blockedId = 2L)
+        assertEquals(1L, block.blockerId)
+        assertEquals(2L, block.blockedId)
+    }
+}

--- a/services/identity/src/test/kotlin/com/mungcle/identity/domain/model/ReportTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/domain/model/ReportTest.kt
@@ -1,0 +1,51 @@
+package com.mungcle.identity.domain.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class ReportTest {
+
+    @Test
+    fun `자기 자신 신고 시 예외 발생`() {
+        assertThrows<IllegalArgumentException> {
+            Report(reporterId = 1L, reportedId = 1L, reason = "테스트")
+        }
+    }
+
+    @Test
+    fun `신고 사유 빈 문자열이면 예외 발생`() {
+        assertThrows<IllegalArgumentException> {
+            Report(reporterId = 1L, reportedId = 2L, reason = "")
+        }
+    }
+
+    @Test
+    fun `신고 사유 500자 초과 시 예외 발생`() {
+        val longReason = "a".repeat(501)
+        assertThrows<IllegalArgumentException> {
+            Report(reporterId = 1L, reportedId = 2L, reason = longReason)
+        }
+    }
+
+    @Test
+    fun `정상 신고 생성 성공`() {
+        val report = Report(reporterId = 1L, reportedId = 2L, reason = "부적절한 행동")
+        assertEquals(1L, report.reporterId)
+        assertEquals(2L, report.reportedId)
+        assertEquals("부적절한 행동", report.reason)
+    }
+
+    @Test
+    fun `신고 사유 정확히 500자면 성공`() {
+        val maxReason = "a".repeat(500)
+        val report = Report(reporterId = 1L, reportedId = 2L, reason = maxReason)
+        assertEquals(500, report.reason.length)
+    }
+
+    @Test
+    fun `신고 사유 정확히 1자면 성공`() {
+        val report = Report(reporterId = 1L, reportedId = 2L, reason = "a")
+        assertEquals(1, report.reason.length)
+    }
+}

--- a/services/identity/src/test/kotlin/com/mungcle/identity/domain/model/ReportTest.kt
+++ b/services/identity/src/test/kotlin/com/mungcle/identity/domain/model/ReportTest.kt
@@ -1,5 +1,7 @@
 package com.mungcle.identity.domain.model
 
+import com.mungcle.identity.domain.exception.InvalidReportReasonException
+import com.mungcle.identity.domain.exception.ReportSelfException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
@@ -8,14 +10,14 @@ class ReportTest {
 
     @Test
     fun `자기 자신 신고 시 예외 발생`() {
-        assertThrows<IllegalArgumentException> {
+        assertThrows<ReportSelfException> {
             Report(reporterId = 1L, reportedId = 1L, reason = "테스트")
         }
     }
 
     @Test
     fun `신고 사유 빈 문자열이면 예외 발생`() {
-        assertThrows<IllegalArgumentException> {
+        assertThrows<InvalidReportReasonException> {
             Report(reporterId = 1L, reportedId = 2L, reason = "")
         }
     }
@@ -23,7 +25,7 @@ class ReportTest {
     @Test
     fun `신고 사유 500자 초과 시 예외 발생`() {
         val longReason = "a".repeat(501)
-        assertThrows<IllegalArgumentException> {
+        assertThrows<InvalidReportReasonException> {
             Report(reporterId = 1L, reportedId = 2L, reason = longReason)
         }
     }


### PR DESCRIPTION
> **Note:** 기존 PR #5 재생성 (base 브랜치 삭제로 자동 닫힘). 코드리뷰 피드백 반영 완료.

## 개요

Identity 서비스 Users, Blocks, Reports 기능 구현. Task 01(Auth)에 이어지는 수직 슬라이스.

## 변경 유형

- [x] feat: 새 기능

## 구현 내용

### 변경된 서비스

- [x] identity-service

### 상세 변경 사항

**신규 도메인:**
- `Block` 모델 (자기 차단 검증), `Report` 모델 (사유 1~500자 검증)
- `User` 확장: neighborhood, profilePhotoPath, flaggedForReview, deletedAt + softDelete() 메서드

**신규 포트 (10개 UseCase + 2개 Repository):**
- GetUser, GetUsersByIds, UpdateUser, DeleteUser
- CreateBlock, DeleteBlock, ListBlocks, GetBlockedUserIds(양방향), IsBlocked
- CreateReport (3회 누적 → flaggedForReview)

**신규 Application (10개 Handler):**
- UpdateUser: 부분 수정 (non-null 필드만)
- DeleteUser: softDelete + 이메일/카카오ID 익명화
- CreateBlock: idempotent (중복 시 에러 없이 반환)
- CreateReport: 3회 이상 누적 시 flaggedForReview=true

**신규 Infrastructure:**
- BlockEntity, ReportEntity (JPA @Tsid)
- Block/Report SpringDataRepository, Adapter, Mapper
- IdentityGrpcService: 나머지 11 RPC 구현 완료 (16/16 전체)

### 코드리뷰 반영 사항

- **ListBlocks에서 blockedNickname 조회**: `getUsersByIdsUseCase`로 차단 대상 닉네임 bulk 조회
- **도메인 예외 사용**: `Block`/`Report`의 `require()` → `BlockSelfException`/`ReportSelfException` + `InvalidReportReasonException` 추가

## 테스트

- [x] 전체 테스트 통과
- 실행: `./gradlew :services:identity:clean :services:identity:test`

## 체크리스트

- [x] 커밋 메시지 형식 준수
- [x] `./gradlew :services:identity:test` 통과
- [x] PR 제목 70자 이내

🤖 Generated with [Claude Code](https://claude.com/claude-code)