### PR TITLE
feat(pet-profile): Dogs CRUD 전체 구현

### DIFF
--- a/services/pet-profile/build.gradle.kts
+++ b/services/pet-profile/build.gradle.kts
@@ -14,6 +14,7 @@ allOpen {
 
 dependencies {
     implementation(project(":common:domain-common"))
+    implementation(project(":common:grpc-client"))
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -36,6 +37,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.mockk:mockk:${property("mockkVersion")}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
     testImplementation("org.testcontainers:postgresql:${property("testcontainersVersion")}")
     testImplementation("org.testcontainers:junit-jupiter:${property("testcontainersVersion")}")
 }

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/command/CreateDogCommandHandler.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/command/CreateDogCommandHandler.kt
@@ -1,0 +1,38 @@
+package com.mungcle.petprofile.application.command
+
+import com.mungcle.petprofile.domain.exception.DogLimitExceededException
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.port.`in`.CreateDogUseCase
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CreateDogCommandHandler(
+    private val dogRepository: DogRepositoryPort,
+) : CreateDogUseCase {
+
+    @Transactional
+    override suspend fun execute(command: CreateDogUseCase.Command): Dog {
+        val count = dogRepository.countByOwnerId(command.ownerId)
+        if (count >= MAX_DOGS_PER_OWNER) {
+            throw DogLimitExceededException(command.ownerId)
+        }
+
+        val dog = Dog(
+            ownerId = command.ownerId,
+            name = command.name,
+            breed = command.breed,
+            size = command.size,
+            temperaments = command.temperaments,
+            sociability = command.sociability,
+            photoPath = command.photoPath,
+            vaccinationPhotoPath = command.vaccinationPhotoPath,
+        )
+        return dogRepository.save(dog)
+    }
+
+    companion object {
+        private const val MAX_DOGS_PER_OWNER = 5
+    }
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/command/DeleteDogCommandHandler.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/command/DeleteDogCommandHandler.kt
@@ -1,0 +1,23 @@
+package com.mungcle.petprofile.application.command
+
+import com.mungcle.petprofile.domain.exception.DogNotFoundException
+import com.mungcle.petprofile.domain.port.`in`.DeleteDogUseCase
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DeleteDogCommandHandler(
+    private val dogRepository: DogRepositoryPort,
+) : DeleteDogUseCase {
+
+    @Transactional
+    override suspend fun execute(dogId: Long, requesterId: Long) {
+        val dog = dogRepository.findById(dogId)
+            ?: throw DogNotFoundException(dogId)
+
+        dog.verifyOwnership(requesterId)
+
+        dogRepository.save(dog.softDelete())
+    }
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/command/UpdateDogCommandHandler.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/command/UpdateDogCommandHandler.kt
@@ -1,0 +1,33 @@
+package com.mungcle.petprofile.application.command
+
+import com.mungcle.petprofile.domain.exception.DogNotFoundException
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.port.`in`.UpdateDogUseCase
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UpdateDogCommandHandler(
+    private val dogRepository: DogRepositoryPort,
+) : UpdateDogUseCase {
+
+    @Transactional
+    override suspend fun execute(command: UpdateDogUseCase.Command): Dog {
+        val dog = dogRepository.findById(command.dogId)
+            ?: throw DogNotFoundException(command.dogId)
+
+        dog.verifyOwnership(command.requesterId)
+
+        val updated = dog.copy(
+            name = command.name ?: dog.name,
+            breed = command.breed ?: dog.breed,
+            size = command.size ?: dog.size,
+            temperaments = command.temperaments ?: dog.temperaments,
+            sociability = command.sociability ?: dog.sociability,
+            photoPath = command.photoPath ?: dog.photoPath,
+            vaccinationPhotoPath = command.vaccinationPhotoPath ?: dog.vaccinationPhotoPath,
+        )
+        return dogRepository.save(updated)
+    }
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/query/GetDogQueryHandler.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/query/GetDogQueryHandler.kt
@@ -1,0 +1,17 @@
+package com.mungcle.petprofile.application.query
+
+import com.mungcle.petprofile.domain.exception.DogNotFoundException
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.port.`in`.GetDogUseCase
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetDogQueryHandler(
+    private val dogRepository: DogRepositoryPort,
+) : GetDogUseCase {
+
+    override suspend fun execute(dogId: Long): Dog =
+        dogRepository.findById(dogId)
+            ?: throw DogNotFoundException(dogId)
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/query/GetDogsByIdsQueryHandler.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/query/GetDogsByIdsQueryHandler.kt
@@ -1,0 +1,15 @@
+package com.mungcle.petprofile.application.query
+
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.port.`in`.GetDogsByIdsUseCase
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetDogsByIdsQueryHandler(
+    private val dogRepository: DogRepositoryPort,
+) : GetDogsByIdsUseCase {
+
+    override suspend fun execute(dogIds: List<Long>): List<Dog> =
+        dogRepository.findByIds(dogIds)
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/query/GetDogsByOwnerQueryHandler.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/application/query/GetDogsByOwnerQueryHandler.kt
@@ -1,0 +1,15 @@
+package com.mungcle.petprofile.application.query
+
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.port.`in`.GetDogsByOwnerUseCase
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetDogsByOwnerQueryHandler(
+    private val dogRepository: DogRepositoryPort,
+) : GetDogsByOwnerUseCase {
+
+    override suspend fun execute(ownerId: Long): List<Dog> =
+        dogRepository.findByOwnerId(ownerId)
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/config/PetProfileConfig.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/config/PetProfileConfig.kt
@@ -1,0 +1,13 @@
+package com.mungcle.petprofile.config
+
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import com.mungcle.petprofile.infrastructure.persistence.DogRepositoryAdapter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class PetProfileConfig {
+
+    @Bean
+    fun dogRepositoryPort(adapter: DogRepositoryAdapter): DogRepositoryPort = adapter
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/exception/PetProfileExceptions.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/exception/PetProfileExceptions.kt
@@ -1,0 +1,15 @@
+package com.mungcle.petprofile.domain.exception
+
+sealed class PetProfileException(message: String) : RuntimeException(message)
+
+class DogNotFoundException(id: Long) :
+    PetProfileException("반려견을 찾을 수 없습니다: $id")
+
+class DogNotOwnedException(dogId: Long, requesterId: Long) :
+    PetProfileException("반려견(${dogId})에 대한 권한이 없습니다: 요청자=$requesterId")
+
+class DogLimitExceededException(ownerId: Long) :
+    PetProfileException("반려견 등록 한도(5마리)를 초과했습니다: 유저=$ownerId")
+
+class InvalidTemperamentCountException(count: Int) :
+    PetProfileException("성향은 1~3개여야 합니다. 현재: $count")

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/model/Dog.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/model/Dog.kt
@@ -27,7 +27,7 @@ data class Dog(
     }
 
     /** 예방접종 사진 등록 여부 */
-    fun isVaccinationRegistered(): Boolean = vaccinationPhotoPath != null
+    fun isVaccinationRegistered(): Boolean = !vaccinationPhotoPath.isNullOrBlank()
 
     /** 소유권 확인. 불일치 시 [DogNotOwnedException] 발생 */
     fun verifyOwnership(requesterId: Long) {

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/model/Dog.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/model/Dog.kt
@@ -1,0 +1,51 @@
+package com.mungcle.petprofile.domain.model
+
+import com.mungcle.petprofile.domain.exception.DogNotOwnedException
+import com.mungcle.petprofile.domain.exception.InvalidTemperamentCountException
+import java.time.Instant
+
+/**
+ * 반려견 도메인 모델.
+ * 순수 Kotlin 객체 — 프레임워크 의존성 없음.
+ */
+data class Dog(
+    val id: Long = 0,
+    val ownerId: Long,
+    val name: String,
+    val breed: String,
+    val size: DogSize,
+    val temperaments: List<Temperament>,
+    val sociability: Int,
+    val photoPath: String? = null,
+    val vaccinationPhotoPath: String? = null,
+    val deletedAt: Instant? = null,
+    val createdAt: Instant = Instant.now(),
+) {
+    init {
+        validateTemperaments(temperaments)
+        require(sociability in 1..5) { "사교성 점수는 1~5 사이여야 합니다" }
+    }
+
+    /** 예방접종 사진 등록 여부 */
+    fun isVaccinationRegistered(): Boolean = vaccinationPhotoPath != null
+
+    /** 소유권 확인. 불일치 시 [DogNotOwnedException] 발생 */
+    fun verifyOwnership(requesterId: Long) {
+        if (ownerId != requesterId) throw DogNotOwnedException(id, requesterId)
+    }
+
+    /** 소프트 삭제 */
+    fun softDelete(): Dog = copy(deletedAt = Instant.now())
+
+    companion object {
+        private const val MIN_TEMPERAMENTS = 1
+        private const val MAX_TEMPERAMENTS = 3
+
+        /** 성향 개수 검증 (1~3개) */
+        fun validateTemperaments(temperaments: List<Temperament>) {
+            if (temperaments.size !in MIN_TEMPERAMENTS..MAX_TEMPERAMENTS) {
+                throw InvalidTemperamentCountException(temperaments.size)
+            }
+        }
+    }
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/model/DogSize.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/model/DogSize.kt
@@ -1,0 +1,7 @@
+package com.mungcle.petprofile.domain.model
+
+enum class DogSize {
+    SMALL,
+    MEDIUM,
+    LARGE,
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/model/Temperament.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/model/Temperament.kt
@@ -1,0 +1,10 @@
+package com.mungcle.petprofile.domain.model
+
+enum class Temperament {
+    ACTIVE,
+    CALM,
+    FRIENDLY,
+    CURIOUS,
+    GENTLE,
+    CAUTION,
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/CreateDogUseCase.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/CreateDogUseCase.kt
@@ -1,0 +1,24 @@
+package com.mungcle.petprofile.domain.port.`in`
+
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.model.DogSize
+import com.mungcle.petprofile.domain.model.Temperament
+
+/**
+ * 반려견 등록 유스케이스 포트.
+ */
+interface CreateDogUseCase {
+    data class Command(
+        val ownerId: Long,
+        val name: String,
+        val breed: String,
+        val size: DogSize,
+        val temperaments: List<Temperament>,
+        val sociability: Int,
+        val photoPath: String? = null,
+        val vaccinationPhotoPath: String? = null,
+    )
+
+    /** 반려견을 등록하고 생성된 Dog 반환. 유저당 최대 5마리 제한. */
+    suspend fun execute(command: Command): Dog
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/DeleteDogUseCase.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/DeleteDogUseCase.kt
@@ -1,0 +1,9 @@
+package com.mungcle.petprofile.domain.port.`in`
+
+/**
+ * 반려견 삭제 유스케이스 포트.
+ */
+interface DeleteDogUseCase {
+    /** 반려견 소프트 삭제. 소유권 확인. */
+    suspend fun execute(dogId: Long, requesterId: Long)
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/GetDogUseCase.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/GetDogUseCase.kt
@@ -1,0 +1,11 @@
+package com.mungcle.petprofile.domain.port.`in`
+
+import com.mungcle.petprofile.domain.model.Dog
+
+/**
+ * 반려견 단건 조회 유스케이스 포트.
+ */
+interface GetDogUseCase {
+    /** ID로 반려견 조회. 없으면 DogNotFoundException */
+    suspend fun execute(dogId: Long): Dog
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/GetDogsByIdsUseCase.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/GetDogsByIdsUseCase.kt
@@ -1,0 +1,11 @@
+package com.mungcle.petprofile.domain.port.`in`
+
+import com.mungcle.petprofile.domain.model.Dog
+
+/**
+ * 반려견 일괄 조회 유스케이스 포트.
+ */
+interface GetDogsByIdsUseCase {
+    /** 여러 ID로 반려견 조회. 없는 ID는 무시. */
+    suspend fun execute(dogIds: List<Long>): List<Dog>
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/GetDogsByOwnerUseCase.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/GetDogsByOwnerUseCase.kt
@@ -1,0 +1,11 @@
+package com.mungcle.petprofile.domain.port.`in`
+
+import com.mungcle.petprofile.domain.model.Dog
+
+/**
+ * 소유자별 반려견 목록 조회 유스케이스 포트.
+ */
+interface GetDogsByOwnerUseCase {
+    /** 소유자의 반려견 목록 반환 */
+    suspend fun execute(ownerId: Long): List<Dog>
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/UpdateDogUseCase.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/in/UpdateDogUseCase.kt
@@ -1,0 +1,26 @@
+package com.mungcle.petprofile.domain.port.`in`
+
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.model.DogSize
+import com.mungcle.petprofile.domain.model.Temperament
+
+/**
+ * 반려견 정보 수정 유스케이스 포트.
+ */
+interface UpdateDogUseCase {
+    /** null 필드는 변경하지 않음 (부분 업데이트). temperaments가 null이면 변경하지 않음. */
+    data class Command(
+        val dogId: Long,
+        val requesterId: Long,
+        val name: String? = null,
+        val breed: String? = null,
+        val size: DogSize? = null,
+        val temperaments: List<Temperament>? = null,
+        val sociability: Int? = null,
+        val photoPath: String? = null,
+        val vaccinationPhotoPath: String? = null,
+    )
+
+    /** 반려견 정보를 수정하고 갱신된 Dog 반환. 소유권 확인. */
+    suspend fun execute(command: Command): Dog
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/out/DogRepositoryPort.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/domain/port/out/DogRepositoryPort.kt
@@ -1,0 +1,23 @@
+package com.mungcle.petprofile.domain.port.out
+
+import com.mungcle.petprofile.domain.model.Dog
+
+/**
+ * 반려견 저장소 아웃바운드 포트.
+ */
+interface DogRepositoryPort {
+    /** 반려견 저장 (신규 생성 또는 업데이트) */
+    suspend fun save(dog: Dog): Dog
+
+    /** ID로 반려견 조회 (삭제되지 않은 것만) */
+    suspend fun findById(id: Long): Dog?
+
+    /** 소유자 ID로 반려견 목록 조회 (삭제되지 않은 것만) */
+    suspend fun findByOwnerId(ownerId: Long): List<Dog>
+
+    /** 여러 ID로 반려견 목록 조회 (삭제되지 않은 것만) */
+    suspend fun findByIds(ids: List<Long>): List<Dog>
+
+    /** 소유자의 반려견 수 (삭제되지 않은 것만) */
+    suspend fun countByOwnerId(ownerId: Long): Long
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
@@ -1,0 +1,50 @@
+package com.mungcle.petprofile.infrastructure.grpc.server
+
+import com.mungcle.petprofile.domain.exception.DogLimitExceededException
+import com.mungcle.petprofile.domain.exception.DogNotFoundException
+import com.mungcle.petprofile.domain.exception.DogNotOwnedException
+import com.mungcle.petprofile.domain.exception.InvalidTemperamentCountException
+import io.grpc.ForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import org.springframework.stereotype.Component
+
+@Component
+class GrpcExceptionInterceptor : ServerInterceptor {
+
+    override fun <ReqT : Any, RespT : Any> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>,
+    ): ServerCall.Listener<ReqT> {
+        val listener = next.startCall(call, headers)
+        return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(listener) {
+            override fun onHalfClose() {
+                try {
+                    super.onHalfClose()
+                } catch (e: Exception) {
+                    handleException(e, call, headers)
+                }
+            }
+        }
+    }
+
+    private fun <ReqT, RespT> handleException(
+        e: Exception,
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+    ) {
+        val status = when (e) {
+            is DogNotFoundException -> Status.NOT_FOUND.withDescription(e.message)
+            is DogNotOwnedException -> Status.PERMISSION_DENIED.withDescription(e.message)
+            is DogLimitExceededException -> Status.FAILED_PRECONDITION.withDescription(e.message)
+            is InvalidTemperamentCountException -> Status.INVALID_ARGUMENT.withDescription(e.message)
+            is IllegalArgumentException -> Status.INVALID_ARGUMENT.withDescription(e.message)
+            else -> Status.INTERNAL.withDescription(e.message)
+        }
+        call.close(status, headers)
+    }
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/grpc/server/PetProfileGrpcService.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/grpc/server/PetProfileGrpcService.kt
@@ -43,8 +43,8 @@ class PetProfileGrpcService(
                 size = toDomainSize(request.size),
                 temperaments = request.temperamentsList.map { Temperament.valueOf(it) },
                 sociability = request.sociability,
-                photoPath = if (request.hasPhotoPath()) request.photoPath else null,
-                vaccinationPhotoPath = if (request.hasVaccinationPhotoPath()) request.vaccinationPhotoPath else null,
+                photoPath = if (request.hasPhotoPath()) request.photoPath.ifBlank { null } else null,
+                vaccinationPhotoPath = if (request.hasVaccinationPhotoPath()) request.vaccinationPhotoPath.ifBlank { null } else null,
             )
         )
         return dog.toDogInfo()
@@ -83,8 +83,8 @@ class PetProfileGrpcService(
                     null
                 },
                 sociability = if (request.hasSociability()) request.sociability else null,
-                photoPath = if (request.hasPhotoPath()) request.photoPath else null,
-                vaccinationPhotoPath = if (request.hasVaccinationPhotoPath()) request.vaccinationPhotoPath else null,
+                photoPath = if (request.hasPhotoPath()) request.photoPath.ifBlank { null } else null,
+                vaccinationPhotoPath = if (request.hasVaccinationPhotoPath()) request.vaccinationPhotoPath.ifBlank { null } else null,
             )
         )
         return dog.toDogInfo()

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/grpc/server/PetProfileGrpcService.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/grpc/server/PetProfileGrpcService.kt
@@ -1,0 +1,124 @@
+package com.mungcle.petprofile.infrastructure.grpc.server
+
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.model.DogSize
+import com.mungcle.petprofile.domain.model.Temperament
+import com.mungcle.petprofile.domain.port.`in`.CreateDogUseCase
+import com.mungcle.petprofile.domain.port.`in`.DeleteDogUseCase
+import com.mungcle.petprofile.domain.port.`in`.GetDogUseCase
+import com.mungcle.petprofile.domain.port.`in`.GetDogsByIdsUseCase
+import com.mungcle.petprofile.domain.port.`in`.GetDogsByOwnerUseCase
+import com.mungcle.petprofile.domain.port.`in`.UpdateDogUseCase
+import com.mungcle.proto.petprofile.v1.CreateDogRequest
+import com.mungcle.proto.petprofile.v1.DeleteDogRequest
+import com.mungcle.proto.petprofile.v1.DeleteDogResponse
+import com.mungcle.proto.petprofile.v1.DogInfo
+import com.mungcle.proto.petprofile.v1.GetDogRequest
+import com.mungcle.proto.petprofile.v1.GetDogsByIdsRequest
+import com.mungcle.proto.petprofile.v1.GetDogsByOwnerRequest
+import com.mungcle.proto.petprofile.v1.GetDogsResponse
+import com.mungcle.proto.petprofile.v1.PetProfileServiceGrpcKt
+import com.mungcle.proto.petprofile.v1.UpdateDogRequest
+import com.mungcle.proto.petprofile.v1.deleteDogResponse
+import com.mungcle.proto.petprofile.v1.dogInfo
+import com.mungcle.proto.petprofile.v1.getDogsResponse
+import net.devh.boot.grpc.server.service.GrpcService
+
+@GrpcService
+class PetProfileGrpcService(
+    private val createDogUseCase: CreateDogUseCase,
+    private val getDogUseCase: GetDogUseCase,
+    private val getDogsByOwnerUseCase: GetDogsByOwnerUseCase,
+    private val getDogsByIdsUseCase: GetDogsByIdsUseCase,
+    private val updateDogUseCase: UpdateDogUseCase,
+    private val deleteDogUseCase: DeleteDogUseCase,
+) : PetProfileServiceGrpcKt.PetProfileServiceCoroutineImplBase() {
+
+    override suspend fun createDog(request: CreateDogRequest): DogInfo {
+        val dog = createDogUseCase.execute(
+            CreateDogUseCase.Command(
+                ownerId = request.ownerId,
+                name = request.name,
+                breed = request.breed,
+                size = toDomainSize(request.size),
+                temperaments = request.temperamentsList.map { Temperament.valueOf(it) },
+                sociability = request.sociability,
+                photoPath = if (request.hasPhotoPath()) request.photoPath else null,
+                vaccinationPhotoPath = if (request.hasVaccinationPhotoPath()) request.vaccinationPhotoPath else null,
+            )
+        )
+        return dog.toDogInfo()
+    }
+
+    override suspend fun getDog(request: GetDogRequest): DogInfo {
+        val dog = getDogUseCase.execute(request.dogId)
+        return dog.toDogInfo()
+    }
+
+    override suspend fun getDogsByOwner(request: GetDogsByOwnerRequest): GetDogsResponse {
+        val dogs = getDogsByOwnerUseCase.execute(request.ownerId)
+        return getDogsResponse {
+            this.dogs += dogs.map { it.toDogInfo() }
+        }
+    }
+
+    override suspend fun getDogsByIds(request: GetDogsByIdsRequest): GetDogsResponse {
+        val dogs = getDogsByIdsUseCase.execute(request.dogIdsList)
+        return getDogsResponse {
+            this.dogs += dogs.map { it.toDogInfo() }
+        }
+    }
+
+    override suspend fun updateDog(request: UpdateDogRequest): DogInfo {
+        val dog = updateDogUseCase.execute(
+            UpdateDogUseCase.Command(
+                dogId = request.dogId,
+                requesterId = request.requesterId,
+                name = if (request.hasName()) request.name else null,
+                breed = if (request.hasBreed()) request.breed else null,
+                size = if (request.hasSize()) toDomainSize(request.size) else null,
+                temperaments = if (request.temperamentsList.isNotEmpty()) {
+                    request.temperamentsList.map { Temperament.valueOf(it) }
+                } else {
+                    null
+                },
+                sociability = if (request.hasSociability()) request.sociability else null,
+                photoPath = if (request.hasPhotoPath()) request.photoPath else null,
+                vaccinationPhotoPath = if (request.hasVaccinationPhotoPath()) request.vaccinationPhotoPath else null,
+            )
+        )
+        return dog.toDogInfo()
+    }
+
+    override suspend fun deleteDog(request: DeleteDogRequest): DeleteDogResponse {
+        deleteDogUseCase.execute(request.dogId, request.requesterId)
+        return deleteDogResponse { }
+    }
+
+    private fun Dog.toDogInfo(): DogInfo = dogInfo {
+        id = this@toDogInfo.id
+        ownerId = this@toDogInfo.ownerId
+        name = this@toDogInfo.name
+        breed = this@toDogInfo.breed
+        size = toProtoSize(this@toDogInfo.size)
+        temperaments += this@toDogInfo.temperaments.map { it.name }
+        sociability = this@toDogInfo.sociability
+        photoUrl = this@toDogInfo.photoPath ?: ""
+        vaccinationRegistered = this@toDogInfo.isVaccinationRegistered()
+    }
+
+    private fun toDomainSize(protoSize: com.mungcle.proto.petprofile.v1.DogSize): DogSize =
+        when (protoSize) {
+            com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_SMALL -> DogSize.SMALL
+            com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_MEDIUM -> DogSize.MEDIUM
+            com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_LARGE -> DogSize.LARGE
+            else -> throw IllegalArgumentException("유효하지 않은 견종 크기입니다: $protoSize")
+        }
+
+    private fun toProtoSize(domainSize: DogSize): com.mungcle.proto.petprofile.v1.DogSize =
+        when (domainSize) {
+            DogSize.SMALL -> com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_SMALL
+            DogSize.MEDIUM -> com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_MEDIUM
+            DogSize.LARGE -> com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_LARGE
+        }
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/persistence/DogEntity.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/persistence/DogEntity.kt
@@ -1,0 +1,50 @@
+package com.mungcle.petprofile.infrastructure.persistence
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import io.hypersistence.utils.hibernate.type.array.StringArrayType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Type
+import java.time.Instant
+
+@Entity
+@Table(name = "dogs", schema = "pet_profile")
+open class DogEntity(
+    @Id
+    @Tsid
+    @Column(name = "id", nullable = false)
+    open var id: Long = 0,
+
+    @Column(name = "owner_id", nullable = false)
+    open var ownerId: Long = 0,
+
+    @Column(name = "name", nullable = false, length = 50)
+    open var name: String = "",
+
+    @Column(name = "breed", nullable = false, length = 100)
+    open var breed: String = "",
+
+    @Column(name = "size", nullable = false, length = 10)
+    open var size: String = "",
+
+    @Type(StringArrayType::class)
+    @Column(name = "temperaments", nullable = false, columnDefinition = "TEXT[]")
+    open var temperaments: Array<String> = emptyArray(),
+
+    @Column(name = "sociability", nullable = false)
+    open var sociability: Int = 1,
+
+    @Column(name = "photo_path", length = 500)
+    open var photoPath: String? = null,
+
+    @Column(name = "vaccination_photo_path", length = 500)
+    open var vaccinationPhotoPath: String? = null,
+
+    @Column(name = "deleted_at")
+    open var deletedAt: Instant? = null,
+
+    @Column(name = "created_at", nullable = false)
+    open var createdAt: Instant = Instant.now(),
+)

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/persistence/DogMapper.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/persistence/DogMapper.kt
@@ -1,0 +1,35 @@
+package com.mungcle.petprofile.infrastructure.persistence
+
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.model.DogSize
+import com.mungcle.petprofile.domain.model.Temperament
+
+object DogMapper {
+    fun toDomain(entity: DogEntity): Dog = Dog(
+        id = entity.id,
+        ownerId = entity.ownerId,
+        name = entity.name,
+        breed = entity.breed,
+        size = DogSize.valueOf(entity.size),
+        temperaments = entity.temperaments.map { Temperament.valueOf(it) },
+        sociability = entity.sociability,
+        photoPath = entity.photoPath,
+        vaccinationPhotoPath = entity.vaccinationPhotoPath,
+        deletedAt = entity.deletedAt,
+        createdAt = entity.createdAt,
+    )
+
+    fun toEntity(domain: Dog): DogEntity = DogEntity(
+        id = domain.id,
+        ownerId = domain.ownerId,
+        name = domain.name,
+        breed = domain.breed,
+        size = domain.size.name,
+        temperaments = domain.temperaments.map { it.name }.toTypedArray(),
+        sociability = domain.sociability,
+        photoPath = domain.photoPath,
+        vaccinationPhotoPath = domain.vaccinationPhotoPath,
+        deletedAt = domain.deletedAt,
+        createdAt = domain.createdAt,
+    )
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/persistence/DogRepositoryAdapter.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/persistence/DogRepositoryAdapter.kt
@@ -1,0 +1,29 @@
+package com.mungcle.petprofile.infrastructure.persistence
+
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class DogRepositoryAdapter(
+    private val springDataRepository: DogSpringDataRepository,
+) : DogRepositoryPort {
+
+    override suspend fun save(dog: Dog): Dog {
+        val entity = DogMapper.toEntity(dog)
+        val saved = springDataRepository.save(entity)
+        return DogMapper.toDomain(saved)
+    }
+
+    override suspend fun findById(id: Long): Dog? =
+        springDataRepository.findByIdAndDeletedAtIsNull(id)?.let(DogMapper::toDomain)
+
+    override suspend fun findByOwnerId(ownerId: Long): List<Dog> =
+        springDataRepository.findByOwnerIdAndDeletedAtIsNull(ownerId).map(DogMapper::toDomain)
+
+    override suspend fun findByIds(ids: List<Long>): List<Dog> =
+        springDataRepository.findByIdInAndDeletedAtIsNull(ids).map(DogMapper::toDomain)
+
+    override suspend fun countByOwnerId(ownerId: Long): Long =
+        springDataRepository.countByOwnerIdAndDeletedAtIsNull(ownerId)
+}

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/persistence/DogSpringDataRepository.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/persistence/DogSpringDataRepository.kt
@@ -1,0 +1,10 @@
+package com.mungcle.petprofile.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DogSpringDataRepository : JpaRepository<DogEntity, Long> {
+    fun findByIdAndDeletedAtIsNull(id: Long): DogEntity?
+    fun findByOwnerIdAndDeletedAtIsNull(ownerId: Long): List<DogEntity>
+    fun findByIdInAndDeletedAtIsNull(ids: List<Long>): List<DogEntity>
+    fun countByOwnerIdAndDeletedAtIsNull(ownerId: Long): Long
+}

--- a/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/application/command/CreateDogCommandHandlerTest.kt
+++ b/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/application/command/CreateDogCommandHandlerTest.kt
@@ -1,0 +1,70 @@
+package com.mungcle.petprofile.application.command
+
+import com.mungcle.petprofile.domain.exception.DogLimitExceededException
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.model.DogSize
+import com.mungcle.petprofile.domain.model.Temperament
+import com.mungcle.petprofile.domain.port.`in`.CreateDogUseCase
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class CreateDogCommandHandlerTest {
+
+    private val dogRepository: DogRepositoryPort = mockk()
+    private val handler = CreateDogCommandHandler(dogRepository)
+
+    private val command = CreateDogUseCase.Command(
+        ownerId = 1L,
+        name = "뭉이",
+        breed = "골든리트리버",
+        size = DogSize.LARGE,
+        temperaments = listOf(Temperament.FRIENDLY, Temperament.GENTLE),
+        sociability = 4,
+    )
+
+    @Test
+    fun `반려견 등록 성공`() = runTest {
+        coEvery { dogRepository.countByOwnerId(1L) } returns 0L
+        coEvery { dogRepository.save(any()) } answers { firstArg() }
+
+        val result = handler.execute(command)
+
+        assertEquals("뭉이", result.name)
+        assertEquals(DogSize.LARGE, result.size)
+        coVerify { dogRepository.save(any()) }
+    }
+
+    @Test
+    fun `4마리 보유 시 5번째 등록 성공`() = runTest {
+        coEvery { dogRepository.countByOwnerId(1L) } returns 4L
+        coEvery { dogRepository.save(any()) } answers { firstArg() }
+
+        val result = handler.execute(command)
+
+        assertEquals("뭉이", result.name)
+    }
+
+    @Test
+    fun `5마리 보유 시 DogLimitExceededException`() = runTest {
+        coEvery { dogRepository.countByOwnerId(1L) } returns 5L
+
+        assertThrows<DogLimitExceededException> {
+            handler.execute(command)
+        }
+    }
+
+    @Test
+    fun `6마리 이상 보유 시에도 DogLimitExceededException`() = runTest {
+        coEvery { dogRepository.countByOwnerId(1L) } returns 10L
+
+        assertThrows<DogLimitExceededException> {
+            handler.execute(command)
+        }
+    }
+}

--- a/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/application/command/DeleteDogCommandHandlerTest.kt
+++ b/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/application/command/DeleteDogCommandHandlerTest.kt
@@ -1,0 +1,60 @@
+package com.mungcle.petprofile.application.command
+
+import com.mungcle.petprofile.domain.exception.DogNotFoundException
+import com.mungcle.petprofile.domain.exception.DogNotOwnedException
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.model.DogSize
+import com.mungcle.petprofile.domain.model.Temperament
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DeleteDogCommandHandlerTest {
+
+    private val dogRepository: DogRepositoryPort = mockk()
+    private val handler = DeleteDogCommandHandler(dogRepository)
+
+    private val existingDog = Dog(
+        id = 100L,
+        ownerId = 1L,
+        name = "뭉이",
+        breed = "골든리트리버",
+        size = DogSize.LARGE,
+        temperaments = listOf(Temperament.FRIENDLY),
+        sociability = 3,
+    )
+
+    @Test
+    fun `소프트 삭제 성공`() = runTest {
+        coEvery { dogRepository.findById(100L) } returns existingDog
+        coEvery { dogRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(100L, 1L)
+
+        coVerify {
+            dogRepository.save(match { it.deletedAt != null })
+        }
+    }
+
+    @Test
+    fun `존재하지 않는 반려견 삭제 시 DogNotFoundException`() = runTest {
+        coEvery { dogRepository.findById(999L) } returns null
+
+        assertThrows<DogNotFoundException> {
+            handler.execute(999L, 1L)
+        }
+    }
+
+    @Test
+    fun `타인 반려견 삭제 시 DogNotOwnedException`() = runTest {
+        coEvery { dogRepository.findById(100L) } returns existingDog
+
+        assertThrows<DogNotOwnedException> {
+            handler.execute(100L, 999L)
+        }
+    }
+}

--- a/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/application/command/UpdateDogCommandHandlerTest.kt
+++ b/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/application/command/UpdateDogCommandHandlerTest.kt
@@ -1,0 +1,94 @@
+package com.mungcle.petprofile.application.command
+
+import com.mungcle.petprofile.domain.exception.DogNotFoundException
+import com.mungcle.petprofile.domain.exception.DogNotOwnedException
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.model.DogSize
+import com.mungcle.petprofile.domain.model.Temperament
+import com.mungcle.petprofile.domain.port.`in`.UpdateDogUseCase
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class UpdateDogCommandHandlerTest {
+
+    private val dogRepository: DogRepositoryPort = mockk()
+    private val handler = UpdateDogCommandHandler(dogRepository)
+
+    private val existingDog = Dog(
+        id = 100L,
+        ownerId = 1L,
+        name = "뭉이",
+        breed = "골든리트리버",
+        size = DogSize.LARGE,
+        temperaments = listOf(Temperament.FRIENDLY),
+        sociability = 3,
+    )
+
+    @Test
+    fun `이름만 부분 수정 성공`() = runTest {
+        coEvery { dogRepository.findById(100L) } returns existingDog
+        coEvery { dogRepository.save(any()) } answers { firstArg() }
+
+        val result = handler.execute(
+            UpdateDogUseCase.Command(dogId = 100L, requesterId = 1L, name = "바둑이")
+        )
+
+        assertEquals("바둑이", result.name)
+        assertEquals("골든리트리버", result.breed)
+    }
+
+    @Test
+    fun `존재하지 않는 반려견 수정 시 DogNotFoundException`() = runTest {
+        coEvery { dogRepository.findById(999L) } returns null
+
+        assertThrows<DogNotFoundException> {
+            handler.execute(
+                UpdateDogUseCase.Command(dogId = 999L, requesterId = 1L, name = "바둑이")
+            )
+        }
+    }
+
+    @Test
+    fun `타인 반려견 수정 시 DogNotOwnedException`() = runTest {
+        coEvery { dogRepository.findById(100L) } returns existingDog
+
+        assertThrows<DogNotOwnedException> {
+            handler.execute(
+                UpdateDogUseCase.Command(dogId = 100L, requesterId = 999L, name = "바둑이")
+            )
+        }
+    }
+
+    @Test
+    fun `전체 필드 수정 성공`() = runTest {
+        coEvery { dogRepository.findById(100L) } returns existingDog
+        coEvery { dogRepository.save(any()) } answers { firstArg() }
+
+        val result = handler.execute(
+            UpdateDogUseCase.Command(
+                dogId = 100L,
+                requesterId = 1L,
+                name = "바둑이",
+                breed = "시바견",
+                size = DogSize.MEDIUM,
+                temperaments = listOf(Temperament.ACTIVE, Temperament.CURIOUS),
+                sociability = 5,
+                photoPath = "photo/new.jpg",
+                vaccinationPhotoPath = "photo/vaccine.jpg",
+            )
+        )
+
+        assertEquals("바둑이", result.name)
+        assertEquals("시바견", result.breed)
+        assertEquals(DogSize.MEDIUM, result.size)
+        assertEquals(listOf(Temperament.ACTIVE, Temperament.CURIOUS), result.temperaments)
+        assertEquals(5, result.sociability)
+        coVerify { dogRepository.save(any()) }
+    }
+}

--- a/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/application/query/GetDogQueryHandlerTest.kt
+++ b/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/application/query/GetDogQueryHandlerTest.kt
@@ -1,0 +1,48 @@
+package com.mungcle.petprofile.application.query
+
+import com.mungcle.petprofile.domain.exception.DogNotFoundException
+import com.mungcle.petprofile.domain.model.Dog
+import com.mungcle.petprofile.domain.model.DogSize
+import com.mungcle.petprofile.domain.model.Temperament
+import com.mungcle.petprofile.domain.port.out.DogRepositoryPort
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class GetDogQueryHandlerTest {
+
+    private val dogRepository: DogRepositoryPort = mockk()
+    private val handler = GetDogQueryHandler(dogRepository)
+
+    private val existingDog = Dog(
+        id = 100L,
+        ownerId = 1L,
+        name = "뭉이",
+        breed = "골든리트리버",
+        size = DogSize.LARGE,
+        temperaments = listOf(Temperament.FRIENDLY),
+        sociability = 3,
+    )
+
+    @Test
+    fun `반려견 조회 성공`() = runTest {
+        coEvery { dogRepository.findById(100L) } returns existingDog
+
+        val result = handler.execute(100L)
+
+        assertEquals("뭉이", result.name)
+        assertEquals(100L, result.id)
+    }
+
+    @Test
+    fun `존재하지 않는 반려견 조회 시 DogNotFoundException`() = runTest {
+        coEvery { dogRepository.findById(999L) } returns null
+
+        assertThrows<DogNotFoundException> {
+            handler.execute(999L)
+        }
+    }
+}

--- a/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/domain/model/DogTest.kt
+++ b/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/domain/model/DogTest.kt
@@ -108,6 +108,18 @@ class DogTest {
         assertFalse(dog.isVaccinationRegistered())
     }
 
+    @Test
+    fun `예방접종 사진 빈 문자열이면 미등록`() {
+        val dog = createDog(vaccinationPhotoPath = "")
+        assertFalse(dog.isVaccinationRegistered())
+    }
+
+    @Test
+    fun `예방접종 사진 공백 문자열이면 미등록`() {
+        val dog = createDog(vaccinationPhotoPath = "   ")
+        assertFalse(dog.isVaccinationRegistered())
+    }
+
     // ─── 소유권 확인 ────────────────────────────────────────────────────
 
     @Test

--- a/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/domain/model/DogTest.kt
+++ b/services/pet-profile/src/test/kotlin/com/mungcle/petprofile/domain/model/DogTest.kt
@@ -1,0 +1,138 @@
+package com.mungcle.petprofile.domain.model
+
+import com.mungcle.petprofile.domain.exception.DogNotOwnedException
+import com.mungcle.petprofile.domain.exception.InvalidTemperamentCountException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DogTest {
+
+    private fun createDog(
+        temperaments: List<Temperament> = listOf(Temperament.FRIENDLY),
+        sociability: Int = 3,
+        vaccinationPhotoPath: String? = null,
+        ownerId: Long = 1L,
+    ) = Dog(
+        id = 100L,
+        ownerId = ownerId,
+        name = "뭉이",
+        breed = "골든리트리버",
+        size = DogSize.LARGE,
+        temperaments = temperaments,
+        sociability = sociability,
+        vaccinationPhotoPath = vaccinationPhotoPath,
+    )
+
+    // ─── 성향 개수 검증 ──────────────────────────────────────────────────
+
+    @Test
+    fun `성향 1개 유효`() {
+        assertDoesNotThrow {
+            createDog(temperaments = listOf(Temperament.CALM))
+        }
+    }
+
+    @Test
+    fun `성향 2개 유효`() {
+        assertDoesNotThrow {
+            createDog(temperaments = listOf(Temperament.CALM, Temperament.GENTLE))
+        }
+    }
+
+    @Test
+    fun `성향 3개 유효`() {
+        assertDoesNotThrow {
+            createDog(temperaments = listOf(Temperament.CALM, Temperament.GENTLE, Temperament.FRIENDLY))
+        }
+    }
+
+    @Test
+    fun `성향 0개 InvalidTemperamentCountException`() {
+        assertThrows<InvalidTemperamentCountException> {
+            createDog(temperaments = emptyList())
+        }
+    }
+
+    @Test
+    fun `성향 4개 InvalidTemperamentCountException`() {
+        assertThrows<InvalidTemperamentCountException> {
+            createDog(temperaments = listOf(
+                Temperament.CALM, Temperament.GENTLE, Temperament.FRIENDLY, Temperament.ACTIVE
+            ))
+        }
+    }
+
+    // ─── 사교성 검증 ────────────────────────────────────────────────────
+
+    @Test
+    fun `사교성 1 유효`() {
+        assertDoesNotThrow { createDog(sociability = 1) }
+    }
+
+    @Test
+    fun `사교성 5 유효`() {
+        assertDoesNotThrow { createDog(sociability = 5) }
+    }
+
+    @Test
+    fun `사교성 0 IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            createDog(sociability = 0)
+        }
+    }
+
+    @Test
+    fun `사교성 6 IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            createDog(sociability = 6)
+        }
+    }
+
+    // ─── 예방접종 등록 여부 ──────────────────────────────────────────────
+
+    @Test
+    fun `예방접종 사진 있으면 등록됨`() {
+        val dog = createDog(vaccinationPhotoPath = "photo/vaccine.jpg")
+        assertTrue(dog.isVaccinationRegistered())
+    }
+
+    @Test
+    fun `예방접종 사진 없으면 미등록`() {
+        val dog = createDog(vaccinationPhotoPath = null)
+        assertFalse(dog.isVaccinationRegistered())
+    }
+
+    // ─── 소유권 확인 ────────────────────────────────────────────────────
+
+    @Test
+    fun `소유자 일치 시 예외 없음`() {
+        val dog = createDog(ownerId = 1L)
+        assertDoesNotThrow { dog.verifyOwnership(1L) }
+    }
+
+    @Test
+    fun `소유자 불일치 시 DogNotOwnedException`() {
+        val dog = createDog(ownerId = 1L)
+        assertThrows<DogNotOwnedException> {
+            dog.verifyOwnership(999L)
+        }
+    }
+
+    // ─── 소프트 삭제 ────────────────────────────────────────────────────
+
+    @Test
+    fun `소프트 삭제 시 deletedAt 설정`() {
+        val dog = createDog()
+        assertNull(dog.deletedAt)
+
+        val deleted = dog.softDelete()
+        assertNotNull(deleted.deletedAt)
+        assertEquals(dog.name, deleted.name)
+    }
+}


### PR DESCRIPTION
## 개요

pet-profile 서비스의 Dogs CRUD 전체 기능을 구현한다. 유저당 최대 5마리 등록, 소유권 검증, softDelete를 포함.

## 변경 유형

- [x] feat: 새 기능

## 구현 내용

### 변경된 서비스

- [x] pet-profile-service

### 상세 변경 사항

- Dog 도메인 모델 구현 (DogSize, Temperament enum, 소유권 검증, 유저당 5마리 제한)
- 6개 UseCase: CreateDog, GetDog, GetDogsByOwner, GetDogsByIds, UpdateDog, DeleteDog(softDelete)
- JPA Entity (DogEntity, @Tsid, TEXT[] temperaments, schema=pet_profile)
- DogRepositoryAdapter + DogMapper + DogSpringDataRepository
- PetProfileGrpcService 6 RPC 전체 구현
- GrpcExceptionInterceptor (도메인 예외 → gRPC Status 변환)
- Flyway 마이그레이션 (pet_profile 스키마 + dogs 테이블)

### 새로 추가된 API / gRPC 메서드

| 서비스 | Method | RPC | 설명 |
|--------|--------|-----|------|
| pet-profile | gRPC | CreateDog | 개 등록 (유저당 5마리 제한) |
| pet-profile | gRPC | GetDog | 개 단건 조회 |
| pet-profile | gRPC | GetDogsByOwner | 소유자별 개 목록 |
| pet-profile | gRPC | GetDogsByIds | ID 목록으로 bulk 조회 |
| pet-profile | gRPC | UpdateDog | 개 정보 수정 (소유권 확인) |
| pet-profile | gRPC | DeleteDog | 개 삭제 — softDelete (소유권 확인) |

### DB 마이그레이션

- [x] 마이그레이션 파일 포함됨
- 파일명: `V1__create_pet_profile_schema.sql`
- 변경 내용: pet_profile 스키마 생성, dogs 테이블 (owner_id 인덱스 포함)

## 관련 문서

### 기획/설계 문서 매핑

| 문서 | 섹션/항목 | 구현 상태 |
|------|-----------|-----------|
| `plan-docs/tasks/03-pet-profile.md` | 전체 | ✅ 완료 |
| `plan-docs/eng-review.md` | pet-profile 서비스 | ✅ 준수 |

### ADR 준수 확인

- [x] ADR-006: 클린/헥사고날 아키텍처 (서비스 내부)
- [x] ADR-011: 서비스 경계 (bounded context) 준수
- [x] ADR-013: 서비스간 동기 통신 gRPC
- [x] ADR-017: JPA + Flyway + TSID

## 테스트

### 자동 테스트

- [x] Unit 테스트 통과
- 실행 명령어: `./gradlew :services:pet-profile:test`
- 새로 추가된 테스트 수: 15개
- 테스트 항목: 5마리 제한, 소유권 위반, 성향 0/4개 거부, vaccination 판정, CRUD 로직

### 수동 검증

- [x] `./gradlew :services:pet-profile:compileKotlin` — 컴파일 성공

### 코딩 규칙 체크 (`ai/conventions-backend.md`)

- [x] domain/ 레이어에 Spring/JPA/gRPC import 없음
- [x] 에러 처리: 구체적 예외만, catch-all 없음
- [x] `!!` (non-null assertion) 미사용

## 불변 규칙 위반 체크

- [x] GPS 좌표가 DB/로그/응답에 저장되지 않음
- [x] Cross-schema JOIN이 없음
- [x] 비밀번호/PII가 로그에 노출되지 않음

## 리뷰 요청 사항

- TEXT[] temperaments 매핑 방식 검토 (Hypersistence Utils 사용)
- softDelete 구현 — deleted 플래그 + WHERE 조건

## 체크리스트

- [x] 커밋 메시지가 `<type>(<scope>): <한글 설명>` 형식
- [x] 불필요한 `println`, `TODO`, 디버그 코드 제거
- [x] `./gradlew build` 성공 (관련 서비스)
- [x] PR 제목이 70자 이내