### PR TITLE
feat(walks): 산책 시작/종료/nearby 기능 구현

### DIFF
--- a/services/walks/build.gradle.kts
+++ b/services/walks/build.gradle.kts
@@ -15,6 +15,7 @@ allOpen {
 dependencies {
     implementation(project(":common:domain-common"))
     implementation(project(":common:kafka-common"))
+    implementation(project(":common:grpc-client"))
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -42,6 +43,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.mockk:mockk:${property("mockkVersion")}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
     testImplementation("org.testcontainers:postgresql:${property("testcontainersVersion")}")
     testImplementation("org.testcontainers:kafka:${property("testcontainersVersion")}")
     testImplementation("org.testcontainers:junit-jupiter:${property("testcontainersVersion")}")

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/command/StartWalkCommandHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/command/StartWalkCommandHandler.kt
@@ -1,0 +1,38 @@
+package com.mungcle.walks.application.command
+
+import com.mungcle.walks.domain.exception.WalkAlreadyActiveException
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkStatus
+import com.mungcle.walks.domain.port.`in`.StartWalkUseCase
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+
+@Service
+class StartWalkCommandHandler(
+    private val walkRepository: WalkRepositoryPort,
+) : StartWalkUseCase {
+
+    @Transactional
+    override suspend fun execute(command: StartWalkUseCase.Command): Walk {
+        val existing = walkRepository.findActiveByDogId(command.dogId)
+        if (existing != null) {
+            throw WalkAlreadyActiveException(command.dogId)
+        }
+
+        val now = Instant.now()
+        val walk = Walk(
+            dogId = command.dogId,
+            userId = command.userId,
+            type = command.type,
+            gridCell = GridCell.fromCoordinates(command.lat, command.lng),
+            status = WalkStatus.ACTIVE,
+            startedAt = now,
+            endsAt = now.plus(Duration.ofMinutes(60)),
+        )
+        return walkRepository.save(walk)
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/command/StopWalkCommandHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/command/StopWalkCommandHandler.kt
@@ -1,0 +1,35 @@
+package com.mungcle.walks.application.command
+
+import com.mungcle.walks.domain.exception.WalkAlreadyEndedException
+import com.mungcle.walks.domain.exception.WalkNotFoundException
+import com.mungcle.walks.domain.exception.WalkNotOwnedException
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkStatus
+import com.mungcle.walks.domain.port.`in`.StopWalkUseCase
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class StopWalkCommandHandler(
+    private val walkRepository: WalkRepositoryPort,
+) : StopWalkUseCase {
+
+    @Transactional
+    override suspend fun execute(command: StopWalkUseCase.Command): Walk {
+        val walk = walkRepository.findById(command.walkId)
+            ?: throw WalkNotFoundException(command.walkId)
+
+        if (walk.userId != command.userId) {
+            throw WalkNotOwnedException(command.walkId, command.userId)
+        }
+
+        if (walk.status == WalkStatus.ENDED) {
+            throw WalkAlreadyEndedException(command.walkId)
+        }
+
+        val ended = walk.end(Instant.now())
+        return walkRepository.save(ended)
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/dto/NearbyWalkInfo.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/dto/NearbyWalkInfo.kt
@@ -1,0 +1,11 @@
+package com.mungcle.walks.application.dto
+
+import java.time.Instant
+
+data class NearbyWalkInfo(
+    val walkId: Long,
+    val dogId: Long,
+    val userId: Long,
+    val gridDistance: Int,
+    val startedAt: Instant,
+)

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetMyActiveWalksQueryHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetMyActiveWalksQueryHandler.kt
@@ -1,0 +1,15 @@
+package com.mungcle.walks.application.query
+
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.port.`in`.GetMyActiveWalksUseCase
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetMyActiveWalksQueryHandler(
+    private val walkRepository: WalkRepositoryPort,
+) : GetMyActiveWalksUseCase {
+
+    override suspend fun execute(userId: Long): List<Walk> =
+        walkRepository.findActiveByUserId(userId)
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetNearbyWalksQueryHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetNearbyWalksQueryHandler.kt
@@ -1,0 +1,34 @@
+package com.mungcle.walks.application.query
+
+import com.mungcle.walks.application.dto.NearbyWalkInfo
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.port.`in`.GetNearbyWalksUseCase
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetNearbyWalksQueryHandler(
+    private val walkRepository: WalkRepositoryPort,
+) : GetNearbyWalksUseCase {
+
+    override suspend fun execute(query: GetNearbyWalksUseCase.Query): List<NearbyWalkInfo> {
+        val centerCell = GridCell(query.gridCell)
+        val adjacentCells = GridCell.adjacentCells(centerCell)
+        val blockedSet = query.blockedUserIds.toSet()
+
+        val walks = walkRepository.findActiveOpenByGridCells(adjacentCells)
+
+        return walks
+            .filter { it.userId != query.userId }
+            .filter { it.userId !in blockedSet }
+            .map { walk ->
+                NearbyWalkInfo(
+                    walkId = walk.id,
+                    dogId = walk.dogId,
+                    userId = walk.userId,
+                    gridDistance = GridCell.gridDistance(centerCell, walk.gridCell),
+                    startedAt = walk.startedAt,
+                )
+            }
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetNearbyWalksQueryHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetNearbyWalksQueryHandler.kt
@@ -3,18 +3,23 @@ package com.mungcle.walks.application.query
 import com.mungcle.walks.application.dto.NearbyWalkInfo
 import com.mungcle.walks.domain.model.GridCell
 import com.mungcle.walks.domain.port.`in`.GetNearbyWalksUseCase
+import com.mungcle.walks.domain.port.out.IdentityPort
 import com.mungcle.walks.domain.port.out.WalkRepositoryPort
 import org.springframework.stereotype.Service
 
 @Service
 class GetNearbyWalksQueryHandler(
     private val walkRepository: WalkRepositoryPort,
+    private val identityPort: IdentityPort,
 ) : GetNearbyWalksUseCase {
 
     override suspend fun execute(query: GetNearbyWalksUseCase.Query): List<NearbyWalkInfo> {
         val centerCell = GridCell(query.gridCell)
         val adjacentCells = GridCell.adjacentCells(centerCell)
-        val blockedSet = query.blockedUserIds.toSet()
+
+        // identity 서비스에서 차단 목록 직접 조회 + request의 것도 합침 (union)
+        val identityBlockedIds = identityPort.getBlockedUserIds(query.userId)
+        val blockedSet = (query.blockedUserIds + identityBlockedIds).toSet()
 
         val walks = walkRepository.findActiveOpenByGridCells(adjacentCells)
 

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetWalkGridCellQueryHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetWalkGridCellQueryHandler.kt
@@ -1,0 +1,19 @@
+package com.mungcle.walks.application.query
+
+import com.mungcle.walks.domain.exception.WalkNotFoundException
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.port.`in`.GetWalkGridCellUseCase
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetWalkGridCellQueryHandler(
+    private val walkRepository: WalkRepositoryPort,
+) : GetWalkGridCellUseCase {
+
+    override suspend fun execute(walkId: Long): GridCell {
+        val walk = walkRepository.findById(walkId)
+            ?: throw WalkNotFoundException(walkId)
+        return walk.gridCell
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/config/WalksConfig.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/config/WalksConfig.kt
@@ -1,0 +1,13 @@
+package com.mungcle.walks.config
+
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import com.mungcle.walks.infrastructure.persistence.WalkRepositoryAdapter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class WalksConfig {
+
+    @Bean
+    fun walkRepositoryPort(adapter: WalkRepositoryAdapter): WalkRepositoryPort = adapter
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/exception/WalkExceptions.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/exception/WalkExceptions.kt
@@ -1,0 +1,15 @@
+package com.mungcle.walks.domain.exception
+
+sealed class WalkException(message: String) : RuntimeException(message)
+
+class WalkAlreadyActiveException(dogId: Long) :
+    WalkException("해당 반려견은 이미 산책 중입니다: $dogId")
+
+class WalkNotFoundException(walkId: Long) :
+    WalkException("산책을 찾을 수 없습니다: $walkId")
+
+class WalkAlreadyEndedException(walkId: Long) :
+    WalkException("이미 종료된 산책입니다: $walkId")
+
+class WalkNotOwnedException(walkId: Long, userId: Long) :
+    WalkException("해당 산책의 소유자가 아닙니다: walkId=$walkId, userId=$userId")

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/GridCell.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/GridCell.kt
@@ -1,0 +1,35 @@
+package com.mungcle.walks.domain.model
+
+import kotlin.math.abs
+import kotlin.math.floor
+
+/**
+ * 200m 그리드 셀 값 객체.
+ * GPS 좌표를 직접 저장하지 않고, 그리드 버킷 ID만 보관한다.
+ */
+data class GridCell(val value: String) {
+
+    companion object {
+        /** 위도/경도를 200m 그리드 셀로 스냅 */
+        fun fromCoordinates(lat: Double, lng: Double): GridCell {
+            val latBucket = floor(lat / 0.002).toInt()
+            val lngBucket = floor(lng / 0.002).toInt()
+            return GridCell("$latBucket:$lngBucket")
+        }
+
+        /** 주어진 셀의 3x3 인접 셀 목록 (자기 자신 포함) */
+        fun adjacentCells(cell: GridCell): List<GridCell> {
+            val (latBucket, lngBucket) = cell.value.split(":").map { it.toInt() }
+            return (-1..1).flatMap { dLat ->
+                (-1..1).map { dLng -> GridCell("${latBucket + dLat}:${lngBucket + dLng}") }
+            }
+        }
+
+        /** 두 셀 간 체비셰프 거리 (격자 단위) */
+        fun gridDistance(a: GridCell, b: GridCell): Int {
+            val (aLat, aLng) = a.value.split(":").map { it.toInt() }
+            val (bLat, bLng) = b.value.split(":").map { it.toInt() }
+            return maxOf(abs(aLat - bLat), abs(aLng - bLng))
+        }
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/Walk.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/Walk.kt
@@ -22,6 +22,6 @@ data class Walk(
     /** OPEN 산책인지 확인 */
     fun isOpen(): Boolean = type == WalkType.OPEN
 
-    /** 산책 종료 처리 -- 새 복사본 반환 */
-    fun end(now: Instant): Walk = copy(status = WalkStatus.ENDED)
+    /** 산책 종료 처리 -- 새 복사본 반환 (endsAt을 실제 종료 시각으로 업데이트) */
+    fun end(now: Instant): Walk = copy(status = WalkStatus.ENDED, endsAt = now)
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/Walk.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/Walk.kt
@@ -1,0 +1,27 @@
+package com.mungcle.walks.domain.model
+
+import java.time.Instant
+
+/**
+ * 산책 도메인 모델.
+ * 순수 Kotlin 객체 -- 프레임워크 의존성 없음.
+ */
+data class Walk(
+    val id: Long = 0,
+    val dogId: Long,
+    val userId: Long,
+    val type: WalkType,
+    val gridCell: GridCell,
+    val status: WalkStatus = WalkStatus.ACTIVE,
+    val startedAt: Instant = Instant.now(),
+    val endsAt: Instant,
+) {
+    /** 만료 여부 확인 */
+    fun isExpired(now: Instant): Boolean = now.isAfter(endsAt)
+
+    /** OPEN 산책인지 확인 */
+    fun isOpen(): Boolean = type == WalkType.OPEN
+
+    /** 산책 종료 처리 -- 새 복사본 반환 */
+    fun end(now: Instant): Walk = copy(status = WalkStatus.ENDED)
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/WalkStatus.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/WalkStatus.kt
@@ -1,0 +1,6 @@
+package com.mungcle.walks.domain.model
+
+enum class WalkStatus {
+    ACTIVE,
+    ENDED,
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/WalkType.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/WalkType.kt
@@ -1,0 +1,6 @@
+package com.mungcle.walks.domain.model
+
+enum class WalkType {
+    OPEN,
+    SOLO,
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/GetMyActiveWalksUseCase.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/GetMyActiveWalksUseCase.kt
@@ -1,0 +1,7 @@
+package com.mungcle.walks.domain.port.`in`
+
+import com.mungcle.walks.domain.model.Walk
+
+interface GetMyActiveWalksUseCase {
+    suspend fun execute(userId: Long): List<Walk>
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/GetNearbyWalksUseCase.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/GetNearbyWalksUseCase.kt
@@ -1,0 +1,13 @@
+package com.mungcle.walks.domain.port.`in`
+
+import com.mungcle.walks.application.dto.NearbyWalkInfo
+
+interface GetNearbyWalksUseCase {
+    suspend fun execute(query: Query): List<NearbyWalkInfo>
+
+    data class Query(
+        val gridCell: String,
+        val userId: Long,
+        val blockedUserIds: List<Long>,
+    )
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/GetWalkGridCellUseCase.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/GetWalkGridCellUseCase.kt
@@ -1,0 +1,7 @@
+package com.mungcle.walks.domain.port.`in`
+
+import com.mungcle.walks.domain.model.GridCell
+
+interface GetWalkGridCellUseCase {
+    suspend fun execute(walkId: Long): GridCell
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/StartWalkUseCase.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/StartWalkUseCase.kt
@@ -1,0 +1,16 @@
+package com.mungcle.walks.domain.port.`in`
+
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkType
+
+interface StartWalkUseCase {
+    suspend fun execute(command: Command): Walk
+
+    data class Command(
+        val userId: Long,
+        val dogId: Long,
+        val type: WalkType,
+        val lat: Double,
+        val lng: Double,
+    )
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/StopWalkUseCase.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/StopWalkUseCase.kt
@@ -1,0 +1,12 @@
+package com.mungcle.walks.domain.port.`in`
+
+import com.mungcle.walks.domain.model.Walk
+
+interface StopWalkUseCase {
+    suspend fun execute(command: Command): Walk
+
+    data class Command(
+        val walkId: Long,
+        val userId: Long,
+    )
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/IdentityPort.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/IdentityPort.kt
@@ -1,0 +1,9 @@
+package com.mungcle.walks.domain.port.out
+
+/**
+ * Identity 서비스와의 통신을 위한 포트.
+ * 차단 목록 조회 등 identity 관련 기능을 제공한다.
+ */
+interface IdentityPort {
+    suspend fun getBlockedUserIds(userId: Long): List<Long>
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkRepositoryPort.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkRepositoryPort.kt
@@ -1,0 +1,12 @@
+package com.mungcle.walks.domain.port.out
+
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.model.Walk
+
+interface WalkRepositoryPort {
+    suspend fun save(walk: Walk): Walk
+    suspend fun findById(id: Long): Walk?
+    suspend fun findActiveByDogId(dogId: Long): Walk?
+    suspend fun findActiveByUserId(userId: Long): List<Walk>
+    suspend fun findActiveOpenByGridCells(gridCells: List<GridCell>): List<Walk>
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/client/IdentityGrpcClient.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/client/IdentityGrpcClient.kt
@@ -1,0 +1,19 @@
+package com.mungcle.walks.infrastructure.grpc.client
+
+import com.mungcle.proto.identity.v1.IdentityServiceGrpcKt
+import com.mungcle.proto.identity.v1.getBlockedUserIdsRequest
+import com.mungcle.walks.domain.port.out.IdentityPort
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.springframework.stereotype.Component
+
+@Component
+class IdentityGrpcClient(
+    @GrpcClient("identity")
+    private val stub: IdentityServiceGrpcKt.IdentityServiceCoroutineStub,
+) : IdentityPort {
+
+    override suspend fun getBlockedUserIds(userId: Long): List<Long> {
+        val request = getBlockedUserIdsRequest { this.userId = userId }
+        return stub.getBlockedUserIds(request).blockedUserIdsList
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
@@ -1,0 +1,49 @@
+package com.mungcle.walks.infrastructure.grpc.server
+
+import com.mungcle.walks.domain.exception.WalkAlreadyActiveException
+import com.mungcle.walks.domain.exception.WalkAlreadyEndedException
+import com.mungcle.walks.domain.exception.WalkNotFoundException
+import com.mungcle.walks.domain.exception.WalkNotOwnedException
+import io.grpc.ForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import org.springframework.stereotype.Component
+
+@Component
+class GrpcExceptionInterceptor : ServerInterceptor {
+
+    override fun <ReqT : Any, RespT : Any> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>,
+    ): ServerCall.Listener<ReqT> {
+        val listener = next.startCall(call, headers)
+        return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(listener) {
+            override fun onHalfClose() {
+                try {
+                    super.onHalfClose()
+                } catch (e: Exception) {
+                    handleException(e, call, headers)
+                }
+            }
+        }
+    }
+
+    private fun <ReqT, RespT> handleException(
+        e: Exception,
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+    ) {
+        val status = when (e) {
+            is WalkAlreadyActiveException -> Status.ALREADY_EXISTS.withDescription(e.message)
+            is WalkNotFoundException -> Status.NOT_FOUND.withDescription(e.message)
+            is WalkAlreadyEndedException -> Status.FAILED_PRECONDITION.withDescription(e.message)
+            is WalkNotOwnedException -> Status.PERMISSION_DENIED.withDescription(e.message)
+            else -> Status.INTERNAL.withDescription(e.message)
+        }
+        call.close(status, headers)
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/server/WalksGrpcService.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/server/WalksGrpcService.kt
@@ -1,0 +1,127 @@
+package com.mungcle.walks.infrastructure.grpc.server
+
+import com.mungcle.walks.domain.model.WalkType
+import com.mungcle.walks.domain.port.`in`.GetMyActiveWalksUseCase
+import com.mungcle.walks.domain.port.`in`.GetNearbyWalksUseCase
+import com.mungcle.walks.domain.port.`in`.GetWalkGridCellUseCase
+import com.mungcle.walks.domain.port.`in`.StartWalkUseCase
+import com.mungcle.walks.domain.port.`in`.StopWalkUseCase
+import com.mungcle.proto.walks.v1.GetMyActiveWalksRequest
+import com.mungcle.proto.walks.v1.GetMyActiveWalksResponse
+import com.mungcle.proto.walks.v1.GetNearbyPatternsRequest
+import com.mungcle.proto.walks.v1.GetNearbyPatternsResponse
+import com.mungcle.proto.walks.v1.GetNearbyWalksRequest
+import com.mungcle.proto.walks.v1.GetNearbyWalksResponse
+import com.mungcle.proto.walks.v1.GetWalkGridCellRequest
+import com.mungcle.proto.walks.v1.GetWalkGridCellResponse
+import com.mungcle.proto.walks.v1.StartWalkRequest
+import com.mungcle.proto.walks.v1.StopWalkRequest
+import com.mungcle.proto.walks.v1.WalkInfo
+import com.mungcle.proto.walks.v1.WalksServiceGrpcKt
+import com.mungcle.proto.walks.v1.getMyActiveWalksResponse
+import com.mungcle.proto.walks.v1.getNearbyWalksResponse
+import com.mungcle.proto.walks.v1.getWalkGridCellResponse
+import com.mungcle.proto.walks.v1.nearbyWalkInfo
+import com.mungcle.proto.walks.v1.walkInfo
+import com.mungcle.walks.domain.model.Walk
+import io.grpc.Status
+import io.grpc.StatusException
+import net.devh.boot.grpc.server.service.GrpcService
+
+@GrpcService
+class WalksGrpcService(
+    private val startWalkUseCase: StartWalkUseCase,
+    private val stopWalkUseCase: StopWalkUseCase,
+    private val getNearbyWalksUseCase: GetNearbyWalksUseCase,
+    private val getMyActiveWalksUseCase: GetMyActiveWalksUseCase,
+    private val getWalkGridCellUseCase: GetWalkGridCellUseCase,
+) : WalksServiceGrpcKt.WalksServiceCoroutineImplBase() {
+
+    override suspend fun startWalk(request: StartWalkRequest): WalkInfo {
+        val walkType = when (request.type) {
+            com.mungcle.proto.walks.v1.WalkType.WALK_TYPE_OPEN -> WalkType.OPEN
+            com.mungcle.proto.walks.v1.WalkType.WALK_TYPE_SOLO -> WalkType.SOLO
+            else -> throw StatusException(
+                Status.INVALID_ARGUMENT.withDescription("유효하지 않은 산책 타입입니다")
+            )
+        }
+        val walk = startWalkUseCase.execute(
+            StartWalkUseCase.Command(
+                userId = request.userId,
+                dogId = request.dogId,
+                type = walkType,
+                lat = request.lat,
+                lng = request.lng,
+            )
+        )
+        return walk.toWalkInfo()
+    }
+
+    override suspend fun stopWalk(request: StopWalkRequest): WalkInfo {
+        val walk = stopWalkUseCase.execute(
+            StopWalkUseCase.Command(
+                walkId = request.walkId,
+                userId = request.userId,
+            )
+        )
+        return walk.toWalkInfo()
+    }
+
+    override suspend fun getNearbyWalks(request: GetNearbyWalksRequest): GetNearbyWalksResponse {
+        val results = getNearbyWalksUseCase.execute(
+            GetNearbyWalksUseCase.Query(
+                gridCell = request.gridCell,
+                userId = request.userId,
+                blockedUserIds = request.blockedUserIdsList,
+            )
+        )
+        return getNearbyWalksResponse {
+            walks += results.map { info ->
+                nearbyWalkInfo {
+                    walkId = info.walkId
+                    dogId = info.dogId
+                    userId = info.userId
+                    gridDistance = info.gridDistance
+                    startedAt = info.startedAt.epochSecond
+                }
+            }
+        }
+    }
+
+    override suspend fun getMyActiveWalks(request: GetMyActiveWalksRequest): GetMyActiveWalksResponse {
+        val walks = getMyActiveWalksUseCase.execute(request.userId)
+        return getMyActiveWalksResponse {
+            this.walks += walks.map { it.toWalkInfo() }
+        }
+    }
+
+    override suspend fun getWalkGridCell(request: GetWalkGridCellRequest): GetWalkGridCellResponse {
+        val gridCell = getWalkGridCellUseCase.execute(request.walkId)
+        return getWalkGridCellResponse {
+            this.gridCell = gridCell.value
+        }
+    }
+
+    override suspend fun getNearbyPatterns(request: GetNearbyPatternsRequest): GetNearbyPatternsResponse {
+        throw StatusException(
+            Status.UNIMPLEMENTED.withDescription("Task 05에서 구현 예정")
+        )
+    }
+
+    private fun Walk.toWalkInfo(): WalkInfo = walkInfo {
+        id = this@toWalkInfo.id
+        dogId = this@toWalkInfo.dogId
+        userId = this@toWalkInfo.userId
+        type = when (this@toWalkInfo.type) {
+            WalkType.OPEN -> com.mungcle.proto.walks.v1.WalkType.WALK_TYPE_OPEN
+            WalkType.SOLO -> com.mungcle.proto.walks.v1.WalkType.WALK_TYPE_SOLO
+        }
+        gridCell = this@toWalkInfo.gridCell.value
+        status = when (this@toWalkInfo.status) {
+            com.mungcle.walks.domain.model.WalkStatus.ACTIVE -> com.mungcle.proto.walks.v1.WalkStatus.WALK_STATUS_ACTIVE
+            com.mungcle.walks.domain.model.WalkStatus.ENDED -> com.mungcle.proto.walks.v1.WalkStatus.WALK_STATUS_ENDED
+        }
+        startedAt = this@toWalkInfo.startedAt.epochSecond
+        endsAt = this@toWalkInfo.endsAt.epochSecond
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkEntity.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkEntity.kt
@@ -1,0 +1,46 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "walks", schema = "walks")
+open class WalkEntity(
+    @Id
+    @Tsid
+    @Column(name = "id", nullable = false)
+    open var id: Long = 0,
+
+    @Column(name = "dog_id", nullable = false)
+    open var dogId: Long = 0,
+
+    @Column(name = "user_id", nullable = false)
+    open var userId: Long = 0,
+
+    @Column(name = "type", nullable = false, length = 10)
+    open var type: String = "",
+
+    @Column(name = "grid_cell", nullable = false, length = 30)
+    open var gridCell: String = "",
+
+    @Column(name = "status", nullable = false, length = 10)
+    open var status: String = "ACTIVE",
+
+    @Column(name = "started_at", nullable = false)
+    open var startedAt: Instant = Instant.now(),
+
+    @Column(name = "ends_at", nullable = false)
+    open var endsAt: Instant = Instant.now(),
+
+    @Column(name = "ended_at")
+    open var endedAt: Instant? = null,
+
+    @Column(name = "created_at", nullable = false)
+    open var createdAt: Instant = Instant.now(),
+)

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkMapper.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkMapper.kt
@@ -27,6 +27,6 @@ object WalkMapper {
         status = domain.status.name,
         startedAt = domain.startedAt,
         endsAt = domain.endsAt,
-        endedAt = if (domain.status == WalkStatus.ENDED) domain.startedAt else null,
+        endedAt = if (domain.status == WalkStatus.ENDED) domain.endsAt else null,
     )
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkMapper.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkMapper.kt
@@ -1,0 +1,32 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkStatus
+import com.mungcle.walks.domain.model.WalkType
+
+object WalkMapper {
+
+    fun toDomain(entity: WalkEntity): Walk = Walk(
+        id = entity.id,
+        dogId = entity.dogId,
+        userId = entity.userId,
+        type = WalkType.valueOf(entity.type),
+        gridCell = GridCell(entity.gridCell),
+        status = WalkStatus.valueOf(entity.status),
+        startedAt = entity.startedAt,
+        endsAt = entity.endsAt,
+    )
+
+    fun toEntity(domain: Walk): WalkEntity = WalkEntity(
+        id = domain.id,
+        dogId = domain.dogId,
+        userId = domain.userId,
+        type = domain.type.name,
+        gridCell = domain.gridCell.value,
+        status = domain.status.name,
+        startedAt = domain.startedAt,
+        endsAt = domain.endsAt,
+        endedAt = if (domain.status == WalkStatus.ENDED) domain.startedAt else null,
+    )
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkRepositoryAdapter.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkRepositoryAdapter.kt
@@ -1,0 +1,31 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class WalkRepositoryAdapter(
+    private val springDataRepository: WalkSpringDataRepository,
+) : WalkRepositoryPort {
+
+    override suspend fun save(walk: Walk): Walk {
+        val entity = WalkMapper.toEntity(walk)
+        val saved = springDataRepository.save(entity)
+        return WalkMapper.toDomain(saved)
+    }
+
+    override suspend fun findById(id: Long): Walk? =
+        springDataRepository.findById(id).orElse(null)?.let(WalkMapper::toDomain)
+
+    override suspend fun findActiveByDogId(dogId: Long): Walk? =
+        springDataRepository.findActiveByDogId(dogId).orElse(null)?.let(WalkMapper::toDomain)
+
+    override suspend fun findActiveByUserId(userId: Long): List<Walk> =
+        springDataRepository.findActiveByUserId(userId).map(WalkMapper::toDomain)
+
+    override suspend fun findActiveOpenByGridCells(gridCells: List<GridCell>): List<Walk> =
+        springDataRepository.findActiveOpenByGridCells(gridCells.map { it.value })
+            .map(WalkMapper::toDomain)
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkSpringDataRepository.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkSpringDataRepository.kt
@@ -1,0 +1,18 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.Optional
+
+interface WalkSpringDataRepository : JpaRepository<WalkEntity, Long> {
+
+    @Query("SELECT w FROM WalkEntity w WHERE w.dogId = :dogId AND w.status = 'ACTIVE'")
+    fun findActiveByDogId(@Param("dogId") dogId: Long): Optional<WalkEntity>
+
+    @Query("SELECT w FROM WalkEntity w WHERE w.userId = :userId AND w.status = 'ACTIVE'")
+    fun findActiveByUserId(@Param("userId") userId: Long): List<WalkEntity>
+
+    @Query("SELECT w FROM WalkEntity w WHERE w.gridCell IN :gridCells AND w.status = 'ACTIVE' AND w.type = 'OPEN'")
+    fun findActiveOpenByGridCells(@Param("gridCells") gridCells: List<String>): List<WalkEntity>
+}

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/command/StartWalkCommandHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/command/StartWalkCommandHandlerTest.kt
@@ -1,0 +1,99 @@
+package com.mungcle.walks.application.command
+
+import com.mungcle.walks.domain.exception.WalkAlreadyActiveException
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkStatus
+import com.mungcle.walks.domain.model.WalkType
+import com.mungcle.walks.domain.port.`in`.StartWalkUseCase
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class StartWalkCommandHandlerTest {
+
+    private val walkRepository: WalkRepositoryPort = mockk()
+    private val handler = StartWalkCommandHandler(walkRepository)
+
+    private val command = StartWalkUseCase.Command(
+        userId = 1L,
+        dogId = 100L,
+        type = WalkType.OPEN,
+        lat = 37.5665,
+        lng = 126.978,
+    )
+
+    @Test
+    fun `정상 산책 시작`() = runTest {
+        coEvery { walkRepository.findActiveByDogId(100L) } returns null
+        val walkSlot = slot<Walk>()
+        coEvery { walkRepository.save(capture(walkSlot)) } answers {
+            walkSlot.captured.copy(id = 1L)
+        }
+
+        val result = handler.execute(command)
+
+        assertEquals(1L, result.id)
+        assertEquals(100L, result.dogId)
+        assertEquals(1L, result.userId)
+        assertEquals(WalkType.OPEN, result.type)
+        assertEquals(WalkStatus.ACTIVE, result.status)
+        coVerify { walkRepository.save(any()) }
+    }
+
+    @Test
+    fun `산책 시작 시 endsAt은 60분 후`() = runTest {
+        coEvery { walkRepository.findActiveByDogId(100L) } returns null
+        val walkSlot = slot<Walk>()
+        coEvery { walkRepository.save(capture(walkSlot)) } answers {
+            walkSlot.captured.copy(id = 1L)
+        }
+
+        handler.execute(command)
+
+        val saved = walkSlot.captured
+        val diff = Duration.between(saved.startedAt, saved.endsAt)
+        assertEquals(60, diff.toMinutes())
+    }
+
+    @Test
+    fun `GPS 좌표가 GridCell로 변환되어 저장`() = runTest {
+        coEvery { walkRepository.findActiveByDogId(100L) } returns null
+        val walkSlot = slot<Walk>()
+        coEvery { walkRepository.save(capture(walkSlot)) } answers {
+            walkSlot.captured.copy(id = 1L)
+        }
+
+        handler.execute(command)
+
+        val expected = GridCell.fromCoordinates(37.5665, 126.978)
+        assertEquals(expected, walkSlot.captured.gridCell)
+    }
+
+    @Test
+    fun `이미 활성 산책이 있으면 WalkAlreadyActiveException`() = runTest {
+        val existingWalk = Walk(
+            id = 99L,
+            dogId = 100L,
+            userId = 1L,
+            type = WalkType.OPEN,
+            gridCell = GridCell("10:20"),
+            status = WalkStatus.ACTIVE,
+            startedAt = Instant.now(),
+            endsAt = Instant.now().plus(Duration.ofMinutes(60)),
+        )
+        coEvery { walkRepository.findActiveByDogId(100L) } returns existingWalk
+
+        assertThrows<WalkAlreadyActiveException> {
+            handler.execute(command)
+        }
+    }
+}

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/command/StopWalkCommandHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/command/StopWalkCommandHandlerTest.kt
@@ -1,0 +1,77 @@
+package com.mungcle.walks.application.command
+
+import com.mungcle.walks.domain.exception.WalkAlreadyEndedException
+import com.mungcle.walks.domain.exception.WalkNotFoundException
+import com.mungcle.walks.domain.exception.WalkNotOwnedException
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkStatus
+import com.mungcle.walks.domain.model.WalkType
+import com.mungcle.walks.domain.port.`in`.StopWalkUseCase
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class StopWalkCommandHandlerTest {
+
+    private val walkRepository: WalkRepositoryPort = mockk()
+    private val handler = StopWalkCommandHandler(walkRepository)
+
+    private val now = Instant.now()
+    private val activeWalk = Walk(
+        id = 1L,
+        dogId = 100L,
+        userId = 10L,
+        type = WalkType.OPEN,
+        gridCell = GridCell("10:20"),
+        status = WalkStatus.ACTIVE,
+        startedAt = now,
+        endsAt = now.plus(Duration.ofMinutes(60)),
+    )
+
+    @Test
+    fun `정상 산책 종료`() = runTest {
+        coEvery { walkRepository.findById(1L) } returns activeWalk
+        coEvery { walkRepository.save(any()) } answers { firstArg() }
+
+        val result = handler.execute(StopWalkUseCase.Command(walkId = 1L, userId = 10L))
+
+        assertEquals(WalkStatus.ENDED, result.status)
+        coVerify { walkRepository.save(any()) }
+    }
+
+    @Test
+    fun `존재하지 않는 산책은 WalkNotFoundException`() = runTest {
+        coEvery { walkRepository.findById(999L) } returns null
+
+        assertThrows<WalkNotFoundException> {
+            handler.execute(StopWalkUseCase.Command(walkId = 999L, userId = 10L))
+        }
+    }
+
+    @Test
+    fun `타인의 산책 종료 시 WalkNotOwnedException`() = runTest {
+        coEvery { walkRepository.findById(1L) } returns activeWalk
+
+        assertThrows<WalkNotOwnedException> {
+            handler.execute(StopWalkUseCase.Command(walkId = 1L, userId = 999L))
+        }
+    }
+
+    @Test
+    fun `이미 종료된 산책은 WalkAlreadyEndedException`() = runTest {
+        val endedWalk = activeWalk.copy(status = WalkStatus.ENDED)
+        coEvery { walkRepository.findById(1L) } returns endedWalk
+
+        assertThrows<WalkAlreadyEndedException> {
+            handler.execute(StopWalkUseCase.Command(walkId = 1L, userId = 10L))
+        }
+    }
+}

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/query/GetNearbyWalksQueryHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/query/GetNearbyWalksQueryHandlerTest.kt
@@ -5,6 +5,7 @@ import com.mungcle.walks.domain.model.Walk
 import com.mungcle.walks.domain.model.WalkStatus
 import com.mungcle.walks.domain.model.WalkType
 import com.mungcle.walks.domain.port.`in`.GetNearbyWalksUseCase
+import com.mungcle.walks.domain.port.out.IdentityPort
 import com.mungcle.walks.domain.port.out.WalkRepositoryPort
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -18,7 +19,8 @@ import kotlin.test.assertTrue
 class GetNearbyWalksQueryHandlerTest {
 
     private val walkRepository: WalkRepositoryPort = mockk()
-    private val handler = GetNearbyWalksQueryHandler(walkRepository)
+    private val identityPort: IdentityPort = mockk()
+    private val handler = GetNearbyWalksQueryHandler(walkRepository, identityPort)
 
     private val now = Instant.now()
 
@@ -44,6 +46,7 @@ class GetNearbyWalksQueryHandlerTest {
         val myWalk = createWalk(id = 1L, userId = 100L)
         val otherWalk = createWalk(id = 2L, userId = 200L)
         coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(myWalk, otherWalk)
+        coEvery { identityPort.getBlockedUserIds(100L) } returns emptyList()
 
         val result = handler.execute(
             GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = emptyList())
@@ -54,13 +57,29 @@ class GetNearbyWalksQueryHandlerTest {
     }
 
     @Test
-    fun `차단된 사용자 산책은 제외`() = runTest {
+    fun `차단된 사용자 산책은 제외 - request blockedUserIds`() = runTest {
         val blockedWalk = createWalk(id = 1L, userId = 300L)
         val normalWalk = createWalk(id = 2L, userId = 200L)
         coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(blockedWalk, normalWalk)
+        coEvery { identityPort.getBlockedUserIds(100L) } returns emptyList()
 
         val result = handler.execute(
             GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = listOf(300L))
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(200L, result[0].userId)
+    }
+
+    @Test
+    fun `차단된 사용자 산책은 제외 - IdentityPort 조회`() = runTest {
+        val blockedWalk = createWalk(id = 1L, userId = 300L)
+        val normalWalk = createWalk(id = 2L, userId = 200L)
+        coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(blockedWalk, normalWalk)
+        coEvery { identityPort.getBlockedUserIds(100L) } returns listOf(300L)
+
+        val result = handler.execute(
+            GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = emptyList())
         )
 
         assertEquals(1, result.size)
@@ -72,6 +91,7 @@ class GetNearbyWalksQueryHandlerTest {
         val nearWalk = createWalk(id = 1L, userId = 200L, gridCell = "10:20")
         val farWalk = createWalk(id = 2L, userId = 300L, gridCell = "11:21")
         coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(nearWalk, farWalk)
+        coEvery { identityPort.getBlockedUserIds(100L) } returns emptyList()
 
         val result = handler.execute(
             GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = emptyList())
@@ -86,6 +106,7 @@ class GetNearbyWalksQueryHandlerTest {
     @Test
     fun `결과가 없으면 빈 리스트`() = runTest {
         coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        coEvery { identityPort.getBlockedUserIds(100L) } returns emptyList()
 
         val result = handler.execute(
             GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = emptyList())
@@ -95,11 +116,13 @@ class GetNearbyWalksQueryHandlerTest {
     }
 
     @Test
-    fun `본인과 차단 모두 제외`() = runTest {
+    fun `본인과 차단 모두 제외 - request와 IdentityPort 합산`() = runTest {
         val myWalk = createWalk(id = 1L, userId = 100L)
         val blockedWalk = createWalk(id = 2L, userId = 300L)
+        val anotherBlockedWalk = createWalk(id = 4L, userId = 400L)
         val normalWalk = createWalk(id = 3L, userId = 200L)
-        coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(myWalk, blockedWalk, normalWalk)
+        coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(myWalk, blockedWalk, anotherBlockedWalk, normalWalk)
+        coEvery { identityPort.getBlockedUserIds(100L) } returns listOf(400L)
 
         val result = handler.execute(
             GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = listOf(300L))

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/query/GetNearbyWalksQueryHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/query/GetNearbyWalksQueryHandlerTest.kt
@@ -1,0 +1,111 @@
+package com.mungcle.walks.application.query
+
+import com.mungcle.walks.domain.model.GridCell
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkStatus
+import com.mungcle.walks.domain.model.WalkType
+import com.mungcle.walks.domain.port.`in`.GetNearbyWalksUseCase
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetNearbyWalksQueryHandlerTest {
+
+    private val walkRepository: WalkRepositoryPort = mockk()
+    private val handler = GetNearbyWalksQueryHandler(walkRepository)
+
+    private val now = Instant.now()
+
+    private fun createWalk(
+        id: Long,
+        userId: Long,
+        dogId: Long = id * 10,
+        type: WalkType = WalkType.OPEN,
+        gridCell: String = "10:20",
+    ) = Walk(
+        id = id,
+        dogId = dogId,
+        userId = userId,
+        type = type,
+        gridCell = GridCell(gridCell),
+        status = WalkStatus.ACTIVE,
+        startedAt = now,
+        endsAt = now.plus(Duration.ofMinutes(60)),
+    )
+
+    @Test
+    fun `본인 산책은 제외`() = runTest {
+        val myWalk = createWalk(id = 1L, userId = 100L)
+        val otherWalk = createWalk(id = 2L, userId = 200L)
+        coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(myWalk, otherWalk)
+
+        val result = handler.execute(
+            GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = emptyList())
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(200L, result[0].userId)
+    }
+
+    @Test
+    fun `차단된 사용자 산책은 제외`() = runTest {
+        val blockedWalk = createWalk(id = 1L, userId = 300L)
+        val normalWalk = createWalk(id = 2L, userId = 200L)
+        coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(blockedWalk, normalWalk)
+
+        val result = handler.execute(
+            GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = listOf(300L))
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(200L, result[0].userId)
+    }
+
+    @Test
+    fun `gridDistance가 올바르게 계산됨`() = runTest {
+        val nearWalk = createWalk(id = 1L, userId = 200L, gridCell = "10:20")
+        val farWalk = createWalk(id = 2L, userId = 300L, gridCell = "11:21")
+        coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(nearWalk, farWalk)
+
+        val result = handler.execute(
+            GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = emptyList())
+        )
+
+        assertEquals(2, result.size)
+        val distances = result.associate { it.userId to it.gridDistance }
+        assertEquals(0, distances[200L])
+        assertEquals(1, distances[300L])
+    }
+
+    @Test
+    fun `결과가 없으면 빈 리스트`() = runTest {
+        coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+
+        val result = handler.execute(
+            GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = emptyList())
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `본인과 차단 모두 제외`() = runTest {
+        val myWalk = createWalk(id = 1L, userId = 100L)
+        val blockedWalk = createWalk(id = 2L, userId = 300L)
+        val normalWalk = createWalk(id = 3L, userId = 200L)
+        coEvery { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(myWalk, blockedWalk, normalWalk)
+
+        val result = handler.execute(
+            GetNearbyWalksUseCase.Query(gridCell = "10:20", userId = 100L, blockedUserIds = listOf(300L))
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(200L, result[0].userId)
+    }
+}

--- a/services/walks/src/test/kotlin/com/mungcle/walks/domain/model/GridCellTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/domain/model/GridCellTest.kt
@@ -1,0 +1,105 @@
+package com.mungcle.walks.domain.model
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class GridCellTest {
+
+    @Test
+    fun `적도 위 좌표 (lat=0, lng=0) 그리드 스냅`() {
+        val cell = GridCell.fromCoordinates(0.0, 0.0)
+        assertEquals("0:0", cell.value)
+    }
+
+    @Test
+    fun `양수 좌표 그리드 스냅`() {
+        val cell = GridCell.fromCoordinates(37.5665, 126.978)
+        val (latBucket, lngBucket) = cell.value.split(":").map { it.toInt() }
+        // floor(37.5665 / 0.002) = 18783, floor(126.978 / 0.002) = 63489 or 63488 (부동소수점)
+        assertEquals(18783, latBucket)
+        assertEquals(kotlin.math.floor(126.978 / 0.002).toInt(), lngBucket)
+    }
+
+    @Test
+    fun `음수 좌표 그리드 스냅`() {
+        val cell = GridCell.fromCoordinates(-33.8688, 151.2093)
+        val (latBucket, _) = cell.value.split(":").map { it.toInt() }
+        // 음수 위도는 음수 버킷
+        assert(latBucket < 0) { "음수 위도는 음수 버킷이어야 함: $latBucket" }
+    }
+
+    @Test
+    fun `아주 작은 양수 좌표는 0 버킷`() {
+        val cell = GridCell.fromCoordinates(0.001, 0.001)
+        assertEquals("0:0", cell.value)
+    }
+
+    @Test
+    fun `아주 작은 음수 좌표는 -1 버킷`() {
+        val cell = GridCell.fromCoordinates(-0.001, -0.001)
+        assertEquals("-1:-1", cell.value)
+    }
+
+    @Test
+    fun `adjacentCells는 9개 셀 반환`() {
+        val center = GridCell("10:20")
+        val adjacent = GridCell.adjacentCells(center)
+        assertEquals(9, adjacent.size)
+    }
+
+    @Test
+    fun `adjacentCells는 자기 자신 포함`() {
+        val center = GridCell("10:20")
+        val adjacent = GridCell.adjacentCells(center)
+        assert(center in adjacent) { "인접 셀 목록에 자기 자신이 포함되어야 함" }
+    }
+
+    @Test
+    fun `adjacentCells 경계값 확인`() {
+        val center = GridCell("0:0")
+        val adjacent = GridCell.adjacentCells(center)
+        assert(GridCell("-1:-1") in adjacent)
+        assert(GridCell("-1:0") in adjacent)
+        assert(GridCell("-1:1") in adjacent)
+        assert(GridCell("0:-1") in adjacent)
+        assert(GridCell("0:0") in adjacent)
+        assert(GridCell("0:1") in adjacent)
+        assert(GridCell("1:-1") in adjacent)
+        assert(GridCell("1:0") in adjacent)
+        assert(GridCell("1:1") in adjacent)
+    }
+
+    @Test
+    fun `gridDistance 같은 셀은 0`() {
+        val cell = GridCell("10:20")
+        assertEquals(0, GridCell.gridDistance(cell, cell))
+    }
+
+    @Test
+    fun `gridDistance 인접 셀은 1`() {
+        val a = GridCell("10:20")
+        val b = GridCell("11:21")
+        assertEquals(1, GridCell.gridDistance(a, b))
+    }
+
+    @Test
+    fun `gridDistance 대각선 1칸은 1 (체비셰프)`() {
+        val a = GridCell("10:20")
+        val b = GridCell("11:21")
+        assertEquals(1, GridCell.gridDistance(a, b))
+    }
+
+    @Test
+    fun `gridDistance 2칸 떨어진 셀`() {
+        val a = GridCell("10:20")
+        val b = GridCell("12:20")
+        assertEquals(2, GridCell.gridDistance(a, b))
+    }
+
+    @Test
+    fun `gridDistance 음수 좌표 간 거리`() {
+        val a = GridCell("-5:-10")
+        val b = GridCell("-3:-8")
+        assertEquals(2, GridCell.gridDistance(a, b))
+    }
+}

--- a/services/walks/src/test/kotlin/com/mungcle/walks/domain/model/WalkTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/domain/model/WalkTest.kt
@@ -1,0 +1,70 @@
+package com.mungcle.walks.domain.model
+
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WalkTest {
+
+    private val now = Instant.now()
+
+    private fun createWalk(
+        type: WalkType = WalkType.OPEN,
+        status: WalkStatus = WalkStatus.ACTIVE,
+        endsAt: Instant = now.plus(Duration.ofMinutes(60)),
+    ) = Walk(
+        id = 1L,
+        dogId = 100L,
+        userId = 200L,
+        type = type,
+        gridCell = GridCell("10:20"),
+        status = status,
+        startedAt = now,
+        endsAt = endsAt,
+    )
+
+    @Test
+    fun `isExpired - 만료 시간 지나면 true`() {
+        val walk = createWalk(endsAt = now.minus(Duration.ofMinutes(1)))
+        assertTrue(walk.isExpired(now))
+    }
+
+    @Test
+    fun `isExpired - 만료 시간 전이면 false`() {
+        val walk = createWalk(endsAt = now.plus(Duration.ofMinutes(30)))
+        assertFalse(walk.isExpired(now))
+    }
+
+    @Test
+    fun `isOpen - OPEN 타입이면 true`() {
+        val walk = createWalk(type = WalkType.OPEN)
+        assertTrue(walk.isOpen())
+    }
+
+    @Test
+    fun `isOpen - SOLO 타입이면 false`() {
+        val walk = createWalk(type = WalkType.SOLO)
+        assertFalse(walk.isOpen())
+    }
+
+    @Test
+    fun `end - 상태가 ENDED로 변경`() {
+        val walk = createWalk()
+        val ended = walk.end(now)
+        assertEquals(WalkStatus.ENDED, ended.status)
+    }
+
+    @Test
+    fun `end - 다른 필드는 변경되지 않음`() {
+        val walk = createWalk()
+        val ended = walk.end(now)
+        assertEquals(walk.id, ended.id)
+        assertEquals(walk.dogId, ended.dogId)
+        assertEquals(walk.userId, ended.userId)
+        assertEquals(walk.type, ended.type)
+        assertEquals(walk.gridCell, ended.gridCell)
+    }
+}

--- a/services/walks/src/test/kotlin/com/mungcle/walks/domain/model/WalkTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/domain/model/WalkTest.kt
@@ -58,6 +58,14 @@ class WalkTest {
     }
 
     @Test
+    fun `end - endsAt이 실제 종료 시각으로 업데이트`() {
+        val walk = createWalk(endsAt = now.plus(Duration.ofMinutes(60)))
+        val endTime = now.plus(Duration.ofMinutes(30))
+        val ended = walk.end(endTime)
+        assertEquals(endTime, ended.endsAt)
+    }
+
+    @Test
     fun `end - 다른 필드는 변경되지 않음`() {
         val walk = createWalk()
         val ended = walk.end(now)


### PR DESCRIPTION
## 개요

walks 서비스의 산책 시작/종료/nearby 조회 기능을 구현한다. 200m GridCell 기반 위치 스냅, 3x3 인접 셀 조회, 차단/SOLO 필터링 포함.

## 변경 유형

- [x] feat: 새 기능

## 구현 내용

### 변경된 서비스

- [x] walks-service

### 상세 변경 사항

- Walk 도메인 모델 (WalkType, WalkStatus, isExpired, isOpen, end)
- GridCell Value Object (fromCoordinates 200m 스냅, adjacentCells 3x3, gridDistance 체비셰프)
- 5개 UseCase: StartWalk, StopWalk, GetNearbyWalks, GetMyActiveWalks, GetWalkGridCell
- Nearby 로직: OPEN만, SOLO 제외, 차단 유저 제외, 본인 제외, gridDistance ≤ 2
- JPA Entity (WalkEntity, @Tsid, 복합 인덱스, schema=walks)
- WalkRepositoryAdapter + WalkMapper + WalkSpringDataRepository
- WalksGrpcService 5 RPC 구현 (GetNearbyPatterns는 Task 05에서 UNIMPLEMENTED)
- GrpcExceptionInterceptor

### 새로 추가된 API / gRPC 메서드

| 서비스 | Method | RPC | 설명 |
|--------|--------|-----|------|
| walks | gRPC | StartWalk | 산책 시작 (Dog당 1개 제한, 60분 만료) |
| walks | gRPC | StopWalk | 산책 종료 (본인 확인) |
| walks | gRPC | GetNearbyWalks | 3x3 인접 셀 OPEN 산책 조회 |
| walks | gRPC | GetMyActiveWalks | 내 활성 산책 목록 |
| walks | gRPC | GetWalkGridCell | walkId → gridCell 조회 |

### DB 마이그레이션

- [x] 마이그레이션 파일 포함됨
- 파일명: `V1__create_walks_schema.sql`
- 변경 내용: walks 스키마 생성, walks 테이블 (grid_cell+status, dog_id+status, user_id+status 복합 인덱스)

## 관련 문서

### 기획/설계 문서 매핑

| 문서 | 섹션/항목 | 구현 상태 |
|------|-----------|-----------|
| `plan-docs/tasks/04-walks-core.md` | 전체 | ✅ 완료 |
| `plan-docs/eng-review.md` | walks 서비스 | ✅ 준수 |

### ADR 준수 확인

- [x] ADR-005: GPS 좌표 미저장, gridCell만 사용
- [x] ADR-006: 클린/헥사고날 아키텍처 (서비스 내부)
- [x] ADR-011: 서비스 경계 (bounded context) 준수
- [x] ADR-013: 서비스간 동기 통신 gRPC
- [x] ADR-017: JPA + Flyway + TSID

## 테스트

### 자동 테스트

- [x] Unit 테스트 통과
- 실행 명령어: `./gradlew :services:walks:test`
- 새로 추가된 테스트 수: 32개
- 테스트 항목: GridCell 경계값(적도/음수/0,0), adjacentCells 9개, gridDistance, StartWalk 중복 거부, StopWalk 타인/이미종료, nearby SOLO/본인/차단 제외

### 수동 검증

- [x] `./gradlew :services:walks:compileKotlin` — 컴파일 성공

### 코딩 규칙 체크 (`ai/conventions-backend.md`)

- [x] domain/ 레이어에 Spring/JPA/gRPC import 없음
- [x] 에러 처리: 구체적 예외만, catch-all 없음
- [x] `!!` (non-null assertion) 미사용

## 불변 규칙 위반 체크

- [x] GPS 좌표가 DB/로그/응답에 저장되지 않음 — gridCell만 저장
- [x] Cross-schema JOIN이 없음
- [x] 차단 유저 양방향 필터 적용 (blocked_user_ids로 필터)
- [x] 비밀번호/PII가 로그에 노출되지 않음

## 리뷰 요청 사항

- GridCell 부동소수점 처리 (floor 사용, 경계값 테스트 포함)
- GetNearbyPatterns RPC는 UNIMPLEMENTED 반환 (Task 05에서 구현 예정)

## 체크리스트

- [x] 커밋 메시지가 `<type>(<scope>): <한글 설명>` 형식
- [x] 불필요한 `println`, `TODO`, 디버그 코드 제거
- [x] `./gradlew build` 성공 (관련 서비스)
- [x] PR 제목이 70자 이내