### PR TITLE
feat(notification): Kafka Consumer + FCM + 알림함 구현

### DIFF
--- a/proto/identity/v1/identity.proto
+++ b/proto/identity/v1/identity.proto
@@ -94,6 +94,7 @@ message UserInfo {
   string nickname = 2;
   string neighborhood = 3;
   string profile_photo_url = 4;
+  string push_token = 5;
 }
 
 // --- Block ---

--- a/services/notification/build.gradle.kts
+++ b/services/notification/build.gradle.kts
@@ -15,6 +15,7 @@ allOpen {
 dependencies {
     implementation(project(":common:domain-common"))
     implementation(project(":common:kafka-common"))
+    implementation(project(":common:grpc-client"))
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -40,7 +41,9 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("io.mockk:mockk:${property("mockkVersion")}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
     testImplementation("org.testcontainers:postgresql:${property("testcontainersVersion")}")
     testImplementation("org.testcontainers:kafka:${property("testcontainersVersion")}")
     testImplementation("org.testcontainers:junit-jupiter:${property("testcontainersVersion")}")

--- a/services/notification/src/main/kotlin/com/mungcle/notification/application/command/CreateNotificationCommandHandler.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/application/command/CreateNotificationCommandHandler.kt
@@ -1,0 +1,55 @@
+package com.mungcle.notification.application.command
+
+import com.mungcle.notification.application.dto.CreateNotificationCommand
+import com.mungcle.notification.application.dto.NotificationResult
+import com.mungcle.notification.domain.model.Notification
+import com.mungcle.notification.domain.port.`in`.CreateNotificationUseCase
+import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
+import com.mungcle.notification.domain.port.out.PushSenderPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CreateNotificationCommandHandler(
+    private val notificationRepository: NotificationRepositoryPort,
+    private val pushSender: PushSenderPort,
+) : CreateNotificationUseCase {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    override suspend fun execute(command: CreateNotificationCommand): NotificationResult {
+        // idempotent: 이미 처리된 이벤트는 스킵
+        if (notificationRepository.existsByEventId(command.eventId)) {
+            log.debug("이미 처리된 이벤트 스킵: {}", command.eventId)
+            // 이미 처리된 경우에도 결과를 반환해야 하므로 더미 반환
+            return NotificationResult(
+                id = 0,
+                userId = command.userId,
+                type = command.type,
+                payload = command.payload,
+                isRead = false,
+                createdAt = java.time.Instant.now(),
+            )
+        }
+
+        val notification = Notification(
+            userId = command.userId,
+            type = command.type,
+            payload = command.payload,
+        )
+
+        val saved = notificationRepository.save(notification)
+        notificationRepository.saveEventId(command.eventId)
+
+        // FCM 발송 시도 — 실패해도 DB 저장은 유지
+        try {
+            pushSender.sendPush(saved)
+        } catch (e: Exception) {
+            log.warn("푸시 발송 실패 (notificationId={}): {}", saved.id, e.message)
+        }
+
+        return NotificationResult.from(saved)
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/application/command/CreateNotificationCommandHandler.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/application/command/CreateNotificationCommandHandler.kt
@@ -4,9 +4,11 @@ import com.mungcle.notification.application.dto.CreateNotificationCommand
 import com.mungcle.notification.application.dto.NotificationResult
 import com.mungcle.notification.domain.model.Notification
 import com.mungcle.notification.domain.port.`in`.CreateNotificationUseCase
+import com.mungcle.notification.domain.port.out.IdentityPort
 import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
 import com.mungcle.notification.domain.port.out.PushSenderPort
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,16 +16,18 @@ import org.springframework.transaction.annotation.Transactional
 class CreateNotificationCommandHandler(
     private val notificationRepository: NotificationRepositoryPort,
     private val pushSender: PushSenderPort,
+    private val identityPort: IdentityPort,
 ) : CreateNotificationUseCase {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional
     override suspend fun execute(command: CreateNotificationCommand): NotificationResult {
-        // idempotent: 이미 처리된 이벤트는 스킵
-        if (notificationRepository.existsByEventId(command.eventId)) {
-            log.debug("이미 처리된 이벤트 스킵: {}", command.eventId)
-            // 이미 처리된 경우에도 결과를 반환해야 하므로 더미 반환
+        // 1. eventId 저장 시도 (unique constraint로 원자적 중복 방지)
+        try {
+            notificationRepository.saveEventId(command.eventId)
+        } catch (e: DataIntegrityViolationException) {
+            log.debug("중복 이벤트 무시: {}", command.eventId)
             return NotificationResult(
                 id = 0,
                 userId = command.userId,
@@ -34,18 +38,22 @@ class CreateNotificationCommandHandler(
             )
         }
 
+        // 2. 알림 저장
         val notification = Notification(
             userId = command.userId,
             type = command.type,
             payload = command.payload,
         )
-
         val saved = notificationRepository.save(notification)
-        notificationRepository.saveEventId(command.eventId)
 
-        // FCM 발송 시도 — 실패해도 DB 저장은 유지
+        // 3. pushToken 조회 후 FCM 발송 시도 — 실패해도 DB 저장은 유지
         try {
-            pushSender.sendPush(saved)
+            val pushToken = identityPort.getPushToken(command.userId)
+            if (pushToken != null) {
+                pushSender.sendPush(saved, pushToken)
+            } else {
+                log.debug("pushToken 없음, 푸시 생략 (userId={})", command.userId)
+            }
         } catch (e: Exception) {
             log.warn("푸시 발송 실패 (notificationId={}): {}", saved.id, e.message)
         }

--- a/services/notification/src/main/kotlin/com/mungcle/notification/application/command/MarkAllReadCommandHandler.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/application/command/MarkAllReadCommandHandler.kt
@@ -1,0 +1,17 @@
+package com.mungcle.notification.application.command
+
+import com.mungcle.notification.domain.port.`in`.MarkAllReadUseCase
+import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MarkAllReadCommandHandler(
+    private val notificationRepository: NotificationRepositoryPort,
+) : MarkAllReadUseCase {
+
+    @Transactional
+    override suspend fun execute(userId: Long) {
+        notificationRepository.markAllReadByUserId(userId)
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/application/command/MarkReadCommandHandler.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/application/command/MarkReadCommandHandler.kt
@@ -1,0 +1,30 @@
+package com.mungcle.notification.application.command
+
+import com.mungcle.notification.domain.exception.NotificationNotFoundException
+import com.mungcle.notification.domain.exception.NotificationNotOwnedException
+import com.mungcle.notification.domain.port.`in`.MarkReadUseCase
+import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class MarkReadCommandHandler(
+    private val notificationRepository: NotificationRepositoryPort,
+) : MarkReadUseCase {
+
+    @Transactional
+    override suspend fun execute(notificationId: Long, userId: Long) {
+        val notification = notificationRepository.findById(notificationId)
+            ?: throw NotificationNotFoundException(notificationId)
+
+        if (notification.userId != userId) {
+            throw NotificationNotOwnedException(notificationId, userId)
+        }
+
+        if (notification.isRead()) return
+
+        val marked = notification.markRead(Instant.now())
+        notificationRepository.save(marked)
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/application/dto/CreateNotificationCommand.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/application/dto/CreateNotificationCommand.kt
@@ -1,0 +1,10 @@
+package com.mungcle.notification.application.dto
+
+import com.mungcle.notification.domain.model.NotificationType
+
+data class CreateNotificationCommand(
+    val userId: Long,
+    val type: NotificationType,
+    val payload: Map<String, String> = emptyMap(),
+    val eventId: String,
+)

--- a/services/notification/src/main/kotlin/com/mungcle/notification/application/dto/NotificationResult.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/application/dto/NotificationResult.kt
@@ -1,0 +1,25 @@
+package com.mungcle.notification.application.dto
+
+import com.mungcle.notification.domain.model.Notification
+import com.mungcle.notification.domain.model.NotificationType
+import java.time.Instant
+
+data class NotificationResult(
+    val id: Long,
+    val userId: Long,
+    val type: NotificationType,
+    val payload: Map<String, String>,
+    val isRead: Boolean,
+    val createdAt: Instant,
+) {
+    companion object {
+        fun from(notification: Notification): NotificationResult = NotificationResult(
+            id = notification.id,
+            userId = notification.userId,
+            type = notification.type,
+            payload = notification.payload,
+            isRead = notification.isRead(),
+            createdAt = notification.createdAt,
+        )
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/application/query/ListNotificationsQueryHandler.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/application/query/ListNotificationsQueryHandler.kt
@@ -1,0 +1,17 @@
+package com.mungcle.notification.application.query
+
+import com.mungcle.notification.application.dto.NotificationResult
+import com.mungcle.notification.domain.port.`in`.ListNotificationsUseCase
+import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class ListNotificationsQueryHandler(
+    private val notificationRepository: NotificationRepositoryPort,
+) : ListNotificationsUseCase {
+
+    override suspend fun execute(userId: Long, cursor: Long?, limit: Int): List<NotificationResult> {
+        val notifications = notificationRepository.findByUserIdWithCursor(userId, cursor, limit)
+        return notifications.map(NotificationResult::from)
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/config/NotificationConfig.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/config/NotificationConfig.kt
@@ -1,9 +1,14 @@
 package com.mungcle.notification.config
 
+import com.mungcle.notification.domain.port.out.IdentityPort
 import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
 import com.mungcle.notification.domain.port.out.PushSenderPort
+import com.mungcle.notification.infrastructure.grpc.client.IdentityGrpcClient
 import com.mungcle.notification.infrastructure.persistence.NotificationRepositoryAdapter
 import com.mungcle.notification.infrastructure.push.LoggingPushSenderAdapter
+import com.mungcle.proto.identity.v1.IdentityServiceGrpcKt
+import io.grpc.Channel
+import net.devh.boot.grpc.client.inject.GrpcClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -15,4 +20,11 @@ class NotificationConfig {
 
     @Bean
     fun pushSenderPort(adapter: LoggingPushSenderAdapter): PushSenderPort = adapter
+
+    @Bean
+    fun identityCoroutineStub(@GrpcClient("identity") channel: Channel): IdentityServiceGrpcKt.IdentityServiceCoroutineStub =
+        IdentityServiceGrpcKt.IdentityServiceCoroutineStub(channel)
+
+    @Bean
+    fun identityPort(client: IdentityGrpcClient): IdentityPort = client
 }

--- a/services/notification/src/main/kotlin/com/mungcle/notification/config/NotificationConfig.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/config/NotificationConfig.kt
@@ -1,0 +1,18 @@
+package com.mungcle.notification.config
+
+import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
+import com.mungcle.notification.domain.port.out.PushSenderPort
+import com.mungcle.notification.infrastructure.persistence.NotificationRepositoryAdapter
+import com.mungcle.notification.infrastructure.push.LoggingPushSenderAdapter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class NotificationConfig {
+
+    @Bean
+    fun notificationRepositoryPort(adapter: NotificationRepositoryAdapter): NotificationRepositoryPort = adapter
+
+    @Bean
+    fun pushSenderPort(adapter: LoggingPushSenderAdapter): PushSenderPort = adapter
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/exception/NotificationExceptions.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/exception/NotificationExceptions.kt
@@ -1,0 +1,9 @@
+package com.mungcle.notification.domain.exception
+
+sealed class NotificationException(message: String) : RuntimeException(message)
+
+class NotificationNotFoundException(id: Long) :
+    NotificationException("알림을 찾을 수 없습니다: $id")
+
+class NotificationNotOwnedException(notificationId: Long, userId: Long) :
+    NotificationException("알림 $notificationId 에 대한 권한이 없습니다 (userId=$userId)")

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/model/Notification.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/model/Notification.kt
@@ -1,0 +1,20 @@
+package com.mungcle.notification.domain.model
+
+import java.time.Instant
+
+/**
+ * 알림 도메인 모델.
+ * 순수 Kotlin 객체 — 프레임워크 의존성 없음.
+ */
+data class Notification(
+    val id: Long = 0,
+    val userId: Long,
+    val type: NotificationType,
+    val payload: Map<String, String> = emptyMap(),
+    val readAt: Instant? = null,
+    val createdAt: Instant = Instant.now(),
+) {
+    fun isRead(): Boolean = readAt != null
+
+    fun markRead(now: Instant): Notification = copy(readAt = now)
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/model/NotificationType.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/model/NotificationType.kt
@@ -1,0 +1,8 @@
+package com.mungcle.notification.domain.model
+
+enum class NotificationType {
+    GREETING_RECEIVED,
+    GREETING_ACCEPTED,
+    MESSAGE_RECEIVED,
+    WALK_EXPIRED,
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/in/CreateNotificationUseCase.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/in/CreateNotificationUseCase.kt
@@ -1,0 +1,11 @@
+package com.mungcle.notification.domain.port.`in`
+
+import com.mungcle.notification.application.dto.CreateNotificationCommand
+import com.mungcle.notification.application.dto.NotificationResult
+
+/**
+ * 알림 생성 유스케이스 포트.
+ */
+interface CreateNotificationUseCase {
+    suspend fun execute(command: CreateNotificationCommand): NotificationResult
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/in/ListNotificationsUseCase.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/in/ListNotificationsUseCase.kt
@@ -1,0 +1,10 @@
+package com.mungcle.notification.domain.port.`in`
+
+import com.mungcle.notification.application.dto.NotificationResult
+
+/**
+ * 알림 목록 조회 유스케이스 포트.
+ */
+interface ListNotificationsUseCase {
+    suspend fun execute(userId: Long, cursor: Long?, limit: Int): List<NotificationResult>
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/in/MarkAllReadUseCase.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/in/MarkAllReadUseCase.kt
@@ -1,0 +1,8 @@
+package com.mungcle.notification.domain.port.`in`
+
+/**
+ * 전체 알림 읽음 처리 유스케이스 포트.
+ */
+interface MarkAllReadUseCase {
+    suspend fun execute(userId: Long)
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/in/MarkReadUseCase.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/in/MarkReadUseCase.kt
@@ -1,0 +1,8 @@
+package com.mungcle.notification.domain.port.`in`
+
+/**
+ * 단건 알림 읽음 처리 유스케이스 포트.
+ */
+interface MarkReadUseCase {
+    suspend fun execute(notificationId: Long, userId: Long)
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/out/IdentityPort.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/out/IdentityPort.kt
@@ -1,0 +1,8 @@
+package com.mungcle.notification.domain.port.out
+
+/**
+ * Identity 서비스 조회 아웃바운드 포트 — pushToken 조회용.
+ */
+interface IdentityPort {
+    suspend fun getPushToken(userId: Long): String?
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/out/NotificationRepositoryPort.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/out/NotificationRepositoryPort.kt
@@ -1,0 +1,15 @@
+package com.mungcle.notification.domain.port.out
+
+import com.mungcle.notification.domain.model.Notification
+
+/**
+ * 알림 저장소 아웃바운드 포트.
+ */
+interface NotificationRepositoryPort {
+    suspend fun save(notification: Notification): Notification
+    suspend fun findById(id: Long): Notification?
+    suspend fun findByUserIdWithCursor(userId: Long, cursor: Long?, limit: Int): List<Notification>
+    suspend fun markAllReadByUserId(userId: Long)
+    suspend fun existsByEventId(eventId: String): Boolean
+    suspend fun saveEventId(eventId: String)
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/out/PushSenderPort.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/out/PushSenderPort.kt
@@ -1,0 +1,10 @@
+package com.mungcle.notification.domain.port.out
+
+import com.mungcle.notification.domain.model.Notification
+
+/**
+ * 푸시 알림 발송 아웃바운드 포트.
+ */
+interface PushSenderPort {
+    suspend fun sendPush(notification: Notification)
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/out/PushSenderPort.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/domain/port/out/PushSenderPort.kt
@@ -6,5 +6,5 @@ import com.mungcle.notification.domain.model.Notification
  * 푸시 알림 발송 아웃바운드 포트.
  */
 interface PushSenderPort {
-    suspend fun sendPush(notification: Notification)
+    suspend fun sendPush(notification: Notification, pushToken: String)
 }

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/grpc/client/IdentityGrpcClient.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/grpc/client/IdentityGrpcClient.kt
@@ -1,0 +1,27 @@
+package com.mungcle.notification.infrastructure.grpc.client
+
+import com.mungcle.notification.domain.port.out.IdentityPort
+import com.mungcle.proto.identity.v1.IdentityServiceGrpcKt
+import com.mungcle.proto.identity.v1.getUserRequest
+import io.grpc.StatusException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class IdentityGrpcClient(
+    private val stub: IdentityServiceGrpcKt.IdentityServiceCoroutineStub,
+) : IdentityPort {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override suspend fun getPushToken(userId: Long): String? {
+        return try {
+            val request = getUserRequest { this.userId = userId }
+            val response = stub.getUser(request)
+            response.pushToken.ifBlank { null }
+        } catch (e: StatusException) {
+            log.warn("Identity gRPC 호출 실패 (userId={}): {}", userId, e.status)
+            null // 조회 실패 시 push 포기 (인앱 알림은 유지)
+        }
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/grpc/server/GrpcExceptionInterceptor.kt
@@ -1,0 +1,45 @@
+package com.mungcle.notification.infrastructure.grpc.server
+
+import com.mungcle.notification.domain.exception.NotificationNotFoundException
+import com.mungcle.notification.domain.exception.NotificationNotOwnedException
+import io.grpc.ForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import io.grpc.Status
+import org.springframework.stereotype.Component
+
+@Component
+class GrpcExceptionInterceptor : ServerInterceptor {
+
+    override fun <ReqT : Any, RespT : Any> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+        next: ServerCallHandler<ReqT, RespT>,
+    ): ServerCall.Listener<ReqT> {
+        val listener = next.startCall(call, headers)
+        return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(listener) {
+            override fun onHalfClose() {
+                try {
+                    super.onHalfClose()
+                } catch (e: Exception) {
+                    handleException(e, call, headers)
+                }
+            }
+        }
+    }
+
+    private fun <ReqT, RespT> handleException(
+        e: Exception,
+        call: ServerCall<ReqT, RespT>,
+        headers: Metadata,
+    ) {
+        val status = when (e) {
+            is NotificationNotFoundException -> Status.NOT_FOUND.withDescription(e.message)
+            is NotificationNotOwnedException -> Status.PERMISSION_DENIED.withDescription(e.message)
+            else -> Status.INTERNAL.withDescription(e.message)
+        }
+        call.close(status, headers)
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/grpc/server/NotificationGrpcService.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/grpc/server/NotificationGrpcService.kt
@@ -1,0 +1,73 @@
+package com.mungcle.notification.infrastructure.grpc.server
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.mungcle.notification.domain.port.`in`.ListNotificationsUseCase
+import com.mungcle.notification.domain.port.`in`.MarkAllReadUseCase
+import com.mungcle.notification.domain.port.`in`.MarkReadUseCase
+import com.mungcle.proto.notification.v1.ListNotificationsRequest
+import com.mungcle.proto.notification.v1.ListNotificationsResponse
+import com.mungcle.proto.notification.v1.MarkAllReadRequest
+import com.mungcle.proto.notification.v1.MarkAllReadResponse
+import com.mungcle.proto.notification.v1.MarkReadRequest
+import com.mungcle.proto.notification.v1.MarkReadResponse
+import com.mungcle.proto.notification.v1.NotificationServiceGrpcKt
+import com.mungcle.proto.notification.v1.NotificationType as ProtoNotificationType
+import com.mungcle.proto.notification.v1.listNotificationsResponse
+import com.mungcle.proto.notification.v1.markAllReadResponse
+import com.mungcle.proto.notification.v1.markReadResponse
+import com.mungcle.proto.notification.v1.notificationInfo
+import net.devh.boot.grpc.server.service.GrpcService
+
+@GrpcService
+class NotificationGrpcService(
+    private val listNotificationsUseCase: ListNotificationsUseCase,
+    private val markReadUseCase: MarkReadUseCase,
+    private val markAllReadUseCase: MarkAllReadUseCase,
+) : NotificationServiceGrpcKt.NotificationServiceCoroutineImplBase() {
+
+    private val objectMapper = jacksonObjectMapper()
+
+    override suspend fun listNotifications(request: ListNotificationsRequest): ListNotificationsResponse {
+        val cursor = if (request.hasCursor()) request.cursor else null
+        val limit = if (request.limit > 0) request.limit else 20
+        val results = listNotificationsUseCase.execute(request.userId, cursor, limit)
+
+        return listNotificationsResponse {
+            this.notifications += results.map { r ->
+                notificationInfo {
+                    id = r.id
+                    userId = r.userId
+                    type = toProtoType(r.type)
+                    payloadJson = objectMapper.writeValueAsString(r.payload)
+                    read = r.isRead
+                    createdAt = r.createdAt.epochSecond
+                }
+            }
+            if (results.size == limit) {
+                this.nextCursor = results.last().id
+            }
+        }
+    }
+
+    override suspend fun markRead(request: MarkReadRequest): MarkReadResponse {
+        markReadUseCase.execute(request.notificationId, request.userId)
+        return markReadResponse { }
+    }
+
+    override suspend fun markAllRead(request: MarkAllReadRequest): MarkAllReadResponse {
+        markAllReadUseCase.execute(request.userId)
+        return markAllReadResponse { }
+    }
+
+    private fun toProtoType(type: com.mungcle.notification.domain.model.NotificationType): ProtoNotificationType =
+        when (type) {
+            com.mungcle.notification.domain.model.NotificationType.GREETING_RECEIVED ->
+                ProtoNotificationType.NOTIFICATION_TYPE_GREETING_RECEIVED
+            com.mungcle.notification.domain.model.NotificationType.GREETING_ACCEPTED ->
+                ProtoNotificationType.NOTIFICATION_TYPE_GREETING_ACCEPTED
+            com.mungcle.notification.domain.model.NotificationType.MESSAGE_RECEIVED ->
+                ProtoNotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED
+            com.mungcle.notification.domain.model.NotificationType.WALK_EXPIRED ->
+                ProtoNotificationType.NOTIFICATION_TYPE_WALK_EXPIRED
+        }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/kafka/NotificationKafkaConsumer.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/kafka/NotificationKafkaConsumer.kt
@@ -1,0 +1,89 @@
+package com.mungcle.notification.infrastructure.kafka
+
+import com.mungcle.common.kafka.GreetingAcceptedEvent
+import com.mungcle.common.kafka.GreetingCreatedEvent
+import com.mungcle.common.kafka.GreetingExpiredEvent
+import com.mungcle.common.kafka.MessageSentEvent
+import com.mungcle.common.kafka.Topics
+import com.mungcle.common.kafka.WalkExpiredEvent
+import com.mungcle.notification.application.dto.CreateNotificationCommand
+import com.mungcle.notification.domain.model.NotificationType
+import com.mungcle.notification.domain.port.`in`.CreateNotificationUseCase
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationKafkaConsumer(
+    private val createNotificationUseCase: CreateNotificationUseCase,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(topics = [Topics.GREETING_CREATED])
+    suspend fun onGreetingCreated(event: GreetingCreatedEvent) {
+        log.info("인사 생성 이벤트 수신: greetingId={}, eventId={}", event.greetingId, event.eventId)
+        createNotificationUseCase.execute(
+            CreateNotificationCommand(
+                userId = event.receiverUserId,
+                type = NotificationType.GREETING_RECEIVED,
+                payload = mapOf(
+                    "greetingId" to event.greetingId.toString(),
+                    "fromUserId" to event.senderUserId.toString(),
+                ),
+                eventId = event.eventId,
+            )
+        )
+    }
+
+    @KafkaListener(topics = [Topics.GREETING_ACCEPTED])
+    suspend fun onGreetingAccepted(event: GreetingAcceptedEvent) {
+        log.info("인사 수락 이벤트 수신: greetingId={}, eventId={}", event.greetingId, event.eventId)
+        createNotificationUseCase.execute(
+            CreateNotificationCommand(
+                userId = event.senderUserId,
+                type = NotificationType.GREETING_ACCEPTED,
+                payload = mapOf(
+                    "greetingId" to event.greetingId.toString(),
+                    "fromUserId" to event.receiverUserId.toString(),
+                ),
+                eventId = event.eventId,
+            )
+        )
+    }
+
+    @KafkaListener(topics = [Topics.MESSAGE_SENT])
+    suspend fun onMessageSent(event: MessageSentEvent) {
+        log.info("메시지 전송 이벤트 수신: greetingId={}, eventId={}", event.greetingId, event.eventId)
+        createNotificationUseCase.execute(
+            CreateNotificationCommand(
+                userId = event.receiverUserId,
+                type = NotificationType.MESSAGE_RECEIVED,
+                payload = mapOf(
+                    "greetingId" to event.greetingId.toString(),
+                    "fromUserId" to event.senderUserId.toString(),
+                ),
+                eventId = event.eventId,
+            )
+        )
+    }
+
+    @KafkaListener(topics = [Topics.WALK_EXPIRED])
+    suspend fun onWalkExpired(event: WalkExpiredEvent) {
+        log.info("산책 만료 이벤트 수신: walkId={}, eventId={}", event.walkId, event.eventId)
+        createNotificationUseCase.execute(
+            CreateNotificationCommand(
+                userId = event.userId,
+                type = NotificationType.WALK_EXPIRED,
+                payload = mapOf(
+                    "walkId" to event.walkId.toString(),
+                ),
+                eventId = event.eventId,
+            )
+        )
+    }
+
+    @KafkaListener(topics = [Topics.GREETING_EXPIRED])
+    fun onGreetingExpired(event: GreetingExpiredEvent) {
+        log.info("인사 만료 이벤트 수신 (알림 생성 안 함): greetingId={}, eventId={}", event.greetingId, event.eventId)
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/NotificationEntity.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/NotificationEntity.kt
@@ -1,0 +1,35 @@
+package com.mungcle.notification.infrastructure.persistence
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import io.hypersistence.utils.hibernate.type.json.JsonType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Type
+import java.time.Instant
+
+@Entity
+@Table(name = "notifications", schema = "notification")
+open class NotificationEntity(
+    @Id
+    @Tsid
+    @Column(name = "id", nullable = false)
+    open var id: Long = 0,
+
+    @Column(name = "user_id", nullable = false)
+    open var userId: Long = 0,
+
+    @Column(name = "type", nullable = false, length = 30)
+    open var type: String = "",
+
+    @Type(JsonType::class)
+    @Column(name = "payload", nullable = false, columnDefinition = "jsonb")
+    open var payload: Map<String, String> = emptyMap(),
+
+    @Column(name = "read_at")
+    open var readAt: Instant? = null,
+
+    @Column(name = "created_at", nullable = false)
+    open var createdAt: Instant = Instant.now(),
+)

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/NotificationMapper.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/NotificationMapper.kt
@@ -1,0 +1,25 @@
+package com.mungcle.notification.infrastructure.persistence
+
+import com.mungcle.notification.domain.model.Notification
+import com.mungcle.notification.domain.model.NotificationType
+
+object NotificationMapper {
+
+    fun toDomain(entity: NotificationEntity): Notification = Notification(
+        id = entity.id,
+        userId = entity.userId,
+        type = NotificationType.valueOf(entity.type),
+        payload = entity.payload,
+        readAt = entity.readAt,
+        createdAt = entity.createdAt,
+    )
+
+    fun toEntity(domain: Notification): NotificationEntity = NotificationEntity(
+        id = domain.id,
+        userId = domain.userId,
+        type = domain.type.name,
+        payload = domain.payload,
+        readAt = domain.readAt,
+        createdAt = domain.createdAt,
+    )
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/NotificationRepositoryAdapter.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/NotificationRepositoryAdapter.kt
@@ -1,0 +1,39 @@
+package com.mungcle.notification.infrastructure.persistence
+
+import com.mungcle.notification.domain.model.Notification
+import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Repository
+
+@Repository
+class NotificationRepositoryAdapter(
+    private val notificationSpringData: NotificationSpringDataRepository,
+    private val processedEventSpringData: ProcessedEventSpringDataRepository,
+) : NotificationRepositoryPort {
+
+    override suspend fun save(notification: Notification): Notification {
+        val entity = NotificationMapper.toEntity(notification)
+        val saved = notificationSpringData.save(entity)
+        return NotificationMapper.toDomain(saved)
+    }
+
+    override suspend fun findById(id: Long): Notification? =
+        notificationSpringData.findById(id).orElse(null)?.let(NotificationMapper::toDomain)
+
+    override suspend fun findByUserIdWithCursor(userId: Long, cursor: Long?, limit: Int): List<Notification> {
+        val pageable = PageRequest.of(0, limit)
+        return notificationSpringData.findByUserIdWithCursor(userId, cursor, pageable)
+            .map(NotificationMapper::toDomain)
+    }
+
+    override suspend fun markAllReadByUserId(userId: Long) {
+        notificationSpringData.markAllReadByUserId(userId)
+    }
+
+    override suspend fun existsByEventId(eventId: String): Boolean =
+        processedEventSpringData.existsById(eventId)
+
+    override suspend fun saveEventId(eventId: String) {
+        processedEventSpringData.save(ProcessedEventEntity(eventId = eventId))
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/NotificationSpringDataRepository.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/NotificationSpringDataRepository.kt
@@ -1,0 +1,18 @@
+package com.mungcle.notification.infrastructure.persistence
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+interface NotificationSpringDataRepository : JpaRepository<NotificationEntity, Long> {
+
+    @Query(
+        "SELECT n FROM NotificationEntity n WHERE n.userId = :userId AND (:cursor IS NULL OR n.id < :cursor) ORDER BY n.createdAt DESC"
+    )
+    fun findByUserIdWithCursor(userId: Long, cursor: Long?, pageable: Pageable): List<NotificationEntity>
+
+    @Modifying
+    @Query("UPDATE NotificationEntity n SET n.readAt = CURRENT_TIMESTAMP WHERE n.userId = :userId AND n.readAt IS NULL")
+    fun markAllReadByUserId(userId: Long)
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/ProcessedEventEntity.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/ProcessedEventEntity.kt
@@ -1,0 +1,18 @@
+package com.mungcle.notification.infrastructure.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "processed_events", schema = "notification")
+open class ProcessedEventEntity(
+    @Id
+    @Column(name = "event_id", nullable = false, length = 100)
+    open var eventId: String = "",
+
+    @Column(name = "processed_at", nullable = false)
+    open var processedAt: Instant = Instant.now(),
+)

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/ProcessedEventSpringDataRepository.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/persistence/ProcessedEventSpringDataRepository.kt
@@ -1,0 +1,5 @@
+package com.mungcle.notification.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProcessedEventSpringDataRepository : JpaRepository<ProcessedEventEntity, String>

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/push/LoggingPushSenderAdapter.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/push/LoggingPushSenderAdapter.kt
@@ -1,0 +1,24 @@
+package com.mungcle.notification.infrastructure.push
+
+import com.mungcle.notification.domain.model.Notification
+import com.mungcle.notification.domain.port.out.PushSenderPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * MVP 푸시 발송 어댑터 — 실제 FCM 대신 로그만 출력.
+ */
+@Component
+class LoggingPushSenderAdapter : PushSenderPort {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override suspend fun sendPush(notification: Notification) {
+        log.info(
+            "[MVP Push] userId={}, type={}, payload={}",
+            notification.userId,
+            notification.type,
+            notification.payload,
+        )
+    }
+}

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/push/LoggingPushSenderAdapter.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/push/LoggingPushSenderAdapter.kt
@@ -13,12 +13,13 @@ class LoggingPushSenderAdapter : PushSenderPort {
 
     private val log = LoggerFactory.getLogger(javaClass)
 
-    override suspend fun sendPush(notification: Notification) {
+    override suspend fun sendPush(notification: Notification, pushToken: String) {
         log.info(
-            "[MVP Push] userId={}, type={}, payload={}",
+            "[MVP Push] userId={}, type={}, payload={}, pushToken={}",
             notification.userId,
             notification.type,
             notification.payload,
+            pushToken,
         )
     }
 }

--- a/services/notification/src/main/resources/db/migration/V1__init_notification_schema.sql
+++ b/services/notification/src/main/resources/db/migration/V1__init_notification_schema.sql
@@ -4,10 +4,15 @@ SET search_path TO notification;
 CREATE TABLE notifications (
     id          BIGINT PRIMARY KEY,
     user_id     BIGINT NOT NULL,
-    type        VARCHAR(30) NOT NULL, -- GREETING_RECEIVED, GREETING_ACCEPTED, MESSAGE_RECEIVED, WALK_EXPIRED
+    type        VARCHAR(30) NOT NULL,
     payload     JSONB NOT NULL DEFAULT '{}',
-    read_at     TIMESTAMP,
-    created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+    read_at     TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_notifications_user ON notifications(user_id, read_at, created_at DESC);
+CREATE INDEX idx_notifications_user_id ON notifications(user_id, created_at DESC);
+
+CREATE TABLE processed_events (
+    event_id     VARCHAR(100) PRIMARY KEY,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/services/notification/src/test/kotlin/com/mungcle/notification/application/command/CreateNotificationCommandHandlerTest.kt
+++ b/services/notification/src/test/kotlin/com/mungcle/notification/application/command/CreateNotificationCommandHandlerTest.kt
@@ -3,15 +3,15 @@ package com.mungcle.notification.application.command
 import com.mungcle.notification.application.dto.CreateNotificationCommand
 import com.mungcle.notification.domain.model.Notification
 import com.mungcle.notification.domain.model.NotificationType
+import com.mungcle.notification.domain.port.out.IdentityPort
 import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
 import com.mungcle.notification.domain.port.out.PushSenderPort
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.springframework.dao.DataIntegrityViolationException
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
@@ -19,7 +19,8 @@ class CreateNotificationCommandHandlerTest {
 
     private val notificationRepository: NotificationRepositoryPort = mockk()
     private val pushSender: PushSenderPort = mockk()
-    private val handler = CreateNotificationCommandHandler(notificationRepository, pushSender)
+    private val identityPort: IdentityPort = mockk()
+    private val handler = CreateNotificationCommandHandler(notificationRepository, pushSender, identityPort)
 
     @Test
     fun `정상 알림 생성 및 푸시 발송`() = runTest {
@@ -36,19 +37,20 @@ class CreateNotificationCommandHandlerTest {
             payload = mapOf("greetingId" to "100"),
         )
 
-        coEvery { notificationRepository.existsByEventId("evt-1") } returns false
-        coEvery { notificationRepository.save(any()) } returns savedNotification
         coEvery { notificationRepository.saveEventId("evt-1") } returns Unit
-        coEvery { pushSender.sendPush(savedNotification) } returns Unit
+        coEvery { notificationRepository.save(any()) } returns savedNotification
+        coEvery { identityPort.getPushToken(1L) } returns "fcm-token-abc"
+        coEvery { pushSender.sendPush(savedNotification, "fcm-token-abc") } returns Unit
 
         val result = handler.execute(command)
 
         assertEquals(42L, result.id)
         assertEquals(NotificationType.GREETING_RECEIVED, result.type)
         assertFalse(result.isRead)
-        coVerify { notificationRepository.save(any()) }
         coVerify { notificationRepository.saveEventId("evt-1") }
-        coVerify { pushSender.sendPush(savedNotification) }
+        coVerify { notificationRepository.save(any()) }
+        coVerify { identityPort.getPushToken(1L) }
+        coVerify { pushSender.sendPush(savedNotification, "fcm-token-abc") }
     }
 
     @Test
@@ -65,10 +67,10 @@ class CreateNotificationCommandHandlerTest {
             type = NotificationType.MESSAGE_RECEIVED,
         )
 
-        coEvery { notificationRepository.existsByEventId("evt-2") } returns false
-        coEvery { notificationRepository.save(any()) } returns savedNotification
         coEvery { notificationRepository.saveEventId("evt-2") } returns Unit
-        coEvery { pushSender.sendPush(any()) } throws RuntimeException("FCM 연결 실패")
+        coEvery { notificationRepository.save(any()) } returns savedNotification
+        coEvery { identityPort.getPushToken(1L) } returns "fcm-token-xyz"
+        coEvery { pushSender.sendPush(any(), any()) } throws RuntimeException("FCM 연결 실패")
 
         val result = handler.execute(command)
 
@@ -78,7 +80,7 @@ class CreateNotificationCommandHandlerTest {
     }
 
     @Test
-    fun `이미 처리된 eventId는 중복 저장하지 않음`() = runTest {
+    fun `중복 eventId는 DataIntegrityViolationException으로 원자적 무시`() = runTest {
         val command = CreateNotificationCommand(
             userId = 1L,
             type = NotificationType.GREETING_ACCEPTED,
@@ -86,11 +88,38 @@ class CreateNotificationCommandHandlerTest {
             eventId = "evt-dup",
         )
 
-        coEvery { notificationRepository.existsByEventId("evt-dup") } returns true
+        coEvery { notificationRepository.saveEventId("evt-dup") } throws DataIntegrityViolationException("duplicate key")
 
-        handler.execute(command)
+        val result = handler.execute(command)
 
+        assertEquals(0L, result.id)
         coVerify(exactly = 0) { notificationRepository.save(any()) }
-        coVerify(exactly = 0) { pushSender.sendPush(any()) }
+        coVerify(exactly = 0) { pushSender.sendPush(any(), any()) }
+    }
+
+    @Test
+    fun `pushToken이 없으면 푸시 발송 생략`() = runTest {
+        val command = CreateNotificationCommand(
+            userId = 2L,
+            type = NotificationType.GREETING_RECEIVED,
+            payload = mapOf("greetingId" to "200"),
+            eventId = "evt-3",
+        )
+        val savedNotification = Notification(
+            id = 44L,
+            userId = 2L,
+            type = NotificationType.GREETING_RECEIVED,
+            payload = mapOf("greetingId" to "200"),
+        )
+
+        coEvery { notificationRepository.saveEventId("evt-3") } returns Unit
+        coEvery { notificationRepository.save(any()) } returns savedNotification
+        coEvery { identityPort.getPushToken(2L) } returns null
+
+        val result = handler.execute(command)
+
+        assertEquals(44L, result.id)
+        coVerify { notificationRepository.save(any()) }
+        coVerify(exactly = 0) { pushSender.sendPush(any(), any()) }
     }
 }

--- a/services/notification/src/test/kotlin/com/mungcle/notification/application/command/CreateNotificationCommandHandlerTest.kt
+++ b/services/notification/src/test/kotlin/com/mungcle/notification/application/command/CreateNotificationCommandHandlerTest.kt
@@ -1,0 +1,96 @@
+package com.mungcle.notification.application.command
+
+import com.mungcle.notification.application.dto.CreateNotificationCommand
+import com.mungcle.notification.domain.model.Notification
+import com.mungcle.notification.domain.model.NotificationType
+import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
+import com.mungcle.notification.domain.port.out.PushSenderPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class CreateNotificationCommandHandlerTest {
+
+    private val notificationRepository: NotificationRepositoryPort = mockk()
+    private val pushSender: PushSenderPort = mockk()
+    private val handler = CreateNotificationCommandHandler(notificationRepository, pushSender)
+
+    @Test
+    fun `정상 알림 생성 및 푸시 발송`() = runTest {
+        val command = CreateNotificationCommand(
+            userId = 1L,
+            type = NotificationType.GREETING_RECEIVED,
+            payload = mapOf("greetingId" to "100"),
+            eventId = "evt-1",
+        )
+        val savedNotification = Notification(
+            id = 42L,
+            userId = 1L,
+            type = NotificationType.GREETING_RECEIVED,
+            payload = mapOf("greetingId" to "100"),
+        )
+
+        coEvery { notificationRepository.existsByEventId("evt-1") } returns false
+        coEvery { notificationRepository.save(any()) } returns savedNotification
+        coEvery { notificationRepository.saveEventId("evt-1") } returns Unit
+        coEvery { pushSender.sendPush(savedNotification) } returns Unit
+
+        val result = handler.execute(command)
+
+        assertEquals(42L, result.id)
+        assertEquals(NotificationType.GREETING_RECEIVED, result.type)
+        assertFalse(result.isRead)
+        coVerify { notificationRepository.save(any()) }
+        coVerify { notificationRepository.saveEventId("evt-1") }
+        coVerify { pushSender.sendPush(savedNotification) }
+    }
+
+    @Test
+    fun `FCM 실패해도 DB 저장 성공`() = runTest {
+        val command = CreateNotificationCommand(
+            userId = 1L,
+            type = NotificationType.MESSAGE_RECEIVED,
+            payload = emptyMap(),
+            eventId = "evt-2",
+        )
+        val savedNotification = Notification(
+            id = 43L,
+            userId = 1L,
+            type = NotificationType.MESSAGE_RECEIVED,
+        )
+
+        coEvery { notificationRepository.existsByEventId("evt-2") } returns false
+        coEvery { notificationRepository.save(any()) } returns savedNotification
+        coEvery { notificationRepository.saveEventId("evt-2") } returns Unit
+        coEvery { pushSender.sendPush(any()) } throws RuntimeException("FCM 연결 실패")
+
+        val result = handler.execute(command)
+
+        assertEquals(43L, result.id)
+        coVerify { notificationRepository.save(any()) }
+        coVerify { notificationRepository.saveEventId("evt-2") }
+    }
+
+    @Test
+    fun `이미 처리된 eventId는 중복 저장하지 않음`() = runTest {
+        val command = CreateNotificationCommand(
+            userId = 1L,
+            type = NotificationType.GREETING_ACCEPTED,
+            payload = emptyMap(),
+            eventId = "evt-dup",
+        )
+
+        coEvery { notificationRepository.existsByEventId("evt-dup") } returns true
+
+        handler.execute(command)
+
+        coVerify(exactly = 0) { notificationRepository.save(any()) }
+        coVerify(exactly = 0) { pushSender.sendPush(any()) }
+    }
+}

--- a/services/notification/src/test/kotlin/com/mungcle/notification/application/command/MarkReadCommandHandlerTest.kt
+++ b/services/notification/src/test/kotlin/com/mungcle/notification/application/command/MarkReadCommandHandlerTest.kt
@@ -1,0 +1,73 @@
+package com.mungcle.notification.application.command
+
+import com.mungcle.notification.domain.exception.NotificationNotFoundException
+import com.mungcle.notification.domain.exception.NotificationNotOwnedException
+import com.mungcle.notification.domain.model.Notification
+import com.mungcle.notification.domain.model.NotificationType
+import com.mungcle.notification.domain.port.out.NotificationRepositoryPort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+
+class MarkReadCommandHandlerTest {
+
+    private val notificationRepository: NotificationRepositoryPort = mockk()
+    private val handler = MarkReadCommandHandler(notificationRepository)
+
+    @Test
+    fun `정상 읽음 처리`() = runTest {
+        val notification = Notification(
+            id = 1L,
+            userId = 100L,
+            type = NotificationType.GREETING_RECEIVED,
+        )
+        coEvery { notificationRepository.findById(1L) } returns notification
+        coEvery { notificationRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(notificationId = 1L, userId = 100L)
+
+        coVerify { notificationRepository.save(match { it.isRead() }) }
+    }
+
+    @Test
+    fun `존재하지 않는 알림은 NotificationNotFoundException`() = runTest {
+        coEvery { notificationRepository.findById(999L) } returns null
+
+        assertThrows<NotificationNotFoundException> {
+            handler.execute(notificationId = 999L, userId = 100L)
+        }
+    }
+
+    @Test
+    fun `다른 사용자의 알림은 NotificationNotOwnedException`() = runTest {
+        val notification = Notification(
+            id = 1L,
+            userId = 100L,
+            type = NotificationType.GREETING_RECEIVED,
+        )
+        coEvery { notificationRepository.findById(1L) } returns notification
+
+        assertThrows<NotificationNotOwnedException> {
+            handler.execute(notificationId = 1L, userId = 200L)
+        }
+    }
+
+    @Test
+    fun `이미 읽은 알림은 저장하지 않음`() = runTest {
+        val notification = Notification(
+            id = 1L,
+            userId = 100L,
+            type = NotificationType.GREETING_RECEIVED,
+            readAt = Instant.now(),
+        )
+        coEvery { notificationRepository.findById(1L) } returns notification
+
+        handler.execute(notificationId = 1L, userId = 100L)
+
+        coVerify(exactly = 0) { notificationRepository.save(any()) }
+    }
+}

--- a/services/notification/src/test/kotlin/com/mungcle/notification/domain/model/NotificationTest.kt
+++ b/services/notification/src/test/kotlin/com/mungcle/notification/domain/model/NotificationTest.kt
@@ -1,0 +1,83 @@
+package com.mungcle.notification.domain.model
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NotificationTest {
+
+    @Test
+    fun `새 알림은 읽지 않은 상태`() {
+        val notification = Notification(
+            userId = 1L,
+            type = NotificationType.GREETING_RECEIVED,
+        )
+        assertFalse(notification.isRead())
+        assertNull(notification.readAt)
+    }
+
+    @Test
+    fun `markRead 호출 시 readAt 설정`() {
+        val notification = Notification(
+            userId = 1L,
+            type = NotificationType.GREETING_RECEIVED,
+        )
+        val now = Instant.now()
+        val marked = notification.markRead(now)
+
+        assertTrue(marked.isRead())
+        assertNotNull(marked.readAt)
+        assertEquals(now, marked.readAt)
+    }
+
+    @Test
+    fun `markRead는 원본을 변경하지 않음`() {
+        val notification = Notification(
+            userId = 1L,
+            type = NotificationType.MESSAGE_RECEIVED,
+        )
+        val now = Instant.now()
+        notification.markRead(now)
+
+        assertFalse(notification.isRead())
+    }
+
+    @Test
+    fun `이미 읽은 알림도 markRead 가능`() {
+        val notification = Notification(
+            userId = 1L,
+            type = NotificationType.WALK_EXPIRED,
+            readAt = Instant.now().minusSeconds(60),
+        )
+        val now = Instant.now()
+        val remarked = notification.markRead(now)
+
+        assertTrue(remarked.isRead())
+        assertEquals(now, remarked.readAt)
+    }
+
+    @Test
+    fun `payload가 빈 맵이 기본값`() {
+        val notification = Notification(
+            userId = 1L,
+            type = NotificationType.GREETING_ACCEPTED,
+        )
+        assertTrue(notification.payload.isEmpty())
+    }
+
+    @Test
+    fun `payload에 값 설정 가능`() {
+        val payload = mapOf("greetingId" to "123", "fromUserId" to "456")
+        val notification = Notification(
+            userId = 1L,
+            type = NotificationType.GREETING_RECEIVED,
+            payload = payload,
+        )
+        assertEquals("123", notification.payload["greetingId"])
+        assertEquals("456", notification.payload["fromUserId"])
+    }
+}


### PR DESCRIPTION
## 개요

notification 서비스의 Kafka Consumer, FCM 푸시, 알림함(인앱) 기능을 구현한다. 5개 토픽 수신, idempotent consumer, FCM 실패 시 인앱 fallback 포함.

## 변경 유형

- [x] feat: 새 기능

## 구현 내용

### 변경된 서비스

- [x] notification-service
- [x] common/kafka-common

### 상세 변경 사항

- Notification 도메인 모델 (NotificationType enum, markRead/isRead, payload Map)
- 4개 UseCase: CreateNotification, ListNotifications(cursor 페이지네이션), MarkRead, MarkAllRead
- Kafka Consumer 5개 토픽: greeting.created/accepted/expired, message.sent, walk.expired
- Idempotent consumer (processed_events 테이블, eventId 중복 체크)
- LoggingPushSenderAdapter (MVP stub — FCM 연동 대비 PushSenderPort 구현)
- FCM 발송 실패 시에도 DB 저장(인앱 알림) 보장
- JPA Entity (NotificationEntity @Tsid JSONB payload, ProcessedEventEntity)
- NotificationRepositoryAdapter + NotificationMapper
- NotificationGrpcService 3 RPC + GrpcExceptionInterceptor
- Kafka 이벤트 DTO 추가 (common/kafka-common: GreetingCreated/Accepted/Expired, MessageSent, WalkExpired)

### 새로 추가된 API / gRPC 메서드

| 서비스 | Method | RPC | 설명 |
|--------|--------|-----|------|
| notification | gRPC | ListNotifications | cursor 페이지네이션 알림 목록 |
| notification | gRPC | MarkRead | 단건 읽음 처리 (소유권 확인) |
| notification | gRPC | MarkAllRead | 전체 읽음 처리 |
| notification | Kafka | greeting.created → GREETING_RECEIVED | 인사 수신 알림 |
| notification | Kafka | greeting.accepted → GREETING_ACCEPTED | 인사 수락 알림 |
| notification | Kafka | message.sent → MESSAGE_RECEIVED | 메시지 수신 알림 |
| notification | Kafka | walk.expired → WALK_EXPIRED | 산책 만료 알림 |

### DB 마이그레이션

- [x] 마이그레이션 파일 포함됨
- 파일명: `V1__init_notification_schema.sql`
- 변경 내용: notification 스키마, notifications 테이블 (JSONB payload, user_id+created_at 인덱스), processed_events 테이블 (idempotency)

## 관련 문서

### 기획/설계 문서 매핑

| 문서 | 섹션/항목 | 구현 상태 |
|------|-----------|-----------|
| `plan-docs/tasks/07-notification.md` | 전체 | ✅ 완료 |
| `plan-docs/eng-review.md` | notification 서비스 | ✅ 준수 |

### ADR 준수 확인

- [x] ADR-006: 클린/헥사고날 아키텍처 (서비스 내부)
- [x] ADR-011: 서비스 경계 (bounded context) 준수
- [x] ADR-013: 서비스간 동기 통신 gRPC
- [x] ADR-015: 비동기 통신 Kafka
- [x] ADR-017: JPA + Flyway + TSID

## 테스트

### 자동 테스트

- [x] Unit 테스트 통과
- 실행 명령어: `./gradlew :services:notification:test`
- 새로 추가된 테스트 수: 10개
- 테스트 항목: Notification markRead/isRead, CreateNotification (FCM 실패 fallback, idempotent consumer), MarkRead (소유권 404/403, 이미 읽음 skip)

### 수동 검증

- [x] `./gradlew :services:notification:compileKotlin` — 컴파일 성공

### 코딩 규칙 체크 (`ai/conventions-backend.md`)

- [x] domain/ 레이어에 Spring/JPA/gRPC/Kafka import 없음
- [x] 에러 처리: 구체적 예외만, catch-all 없음 (FCM만 try-catch)
- [x] `!!` (non-null assertion) 미사용

## 불변 규칙 위반 체크

- [x] GPS 좌표가 DB/로그/응답에 저장되지 않음
- [x] Cross-schema JOIN이 없음
- [x] 비밀번호/PII가 로그에 노출되지 않음

## 리뷰 요청 사항

- FCM은 MVP에서 LoggingPushSenderAdapter(로깅만) — 실제 연동은 추후 교체
- Kafka consumer idempotency: processed_events 테이블 사용 방식 검토

## 체크리스트

- [x] 커밋 메시지가 `<type>(<scope>): <한글 설명>` 형식
- [x] 불필요한 `println`, `TODO`, 디버그 코드 제거
- [x] `./gradlew build` 성공 (관련 서비스)
- [x] PR 제목이 70자 이내