### PR TITLE
feat(social): 인사 생성/응답 기능 구현

### DIFF
--- a/services/social/build.gradle.kts
+++ b/services/social/build.gradle.kts
@@ -15,6 +15,7 @@ allOpen {
 dependencies {
     implementation(project(":common:domain-common"))
     implementation(project(":common:kafka-common"))
+    implementation(project(":common:grpc-client"))
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -42,6 +43,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.mockk:mockk:${property("mockkVersion")}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
     testImplementation("org.testcontainers:postgresql:${property("testcontainersVersion")}")
     testImplementation("org.testcontainers:kafka:${property("testcontainersVersion")}")
     testImplementation("org.testcontainers:junit-jupiter:${property("testcontainersVersion")}")

--- a/services/social/src/main/kotlin/com/mungcle/social/application/command/CreateGreetingCommandHandler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/application/command/CreateGreetingCommandHandler.kt
@@ -1,0 +1,55 @@
+package com.mungcle.social.application.command
+
+import com.mungcle.social.domain.exception.ForbiddenBlockedException
+import com.mungcle.social.domain.exception.GreetingDuplicateException
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.port.`in`.CreateGreetingUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.IdentityPort
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import com.mungcle.social.domain.port.out.WalksPort
+import kotlinx.coroutines.runBlocking
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class CreateGreetingCommandHandler(
+    private val greetingRepository: GreetingRepositoryPort,
+    private val identityPort: IdentityPort,
+    private val walksPort: WalksPort,
+    private val eventPublisher: SocialEventPublisherPort,
+) : CreateGreetingUseCase {
+
+    @Transactional
+    override fun execute(command: CreateGreetingUseCase.Command): Greeting {
+        val walkInfo = runBlocking { walksPort.getWalk(command.receiverWalkId) }
+
+        val blocked = runBlocking { identityPort.isBlocked(command.senderUserId, walkInfo.userId) }
+        if (blocked) {
+            throw ForbiddenBlockedException(command.senderUserId)
+        }
+
+        val existing = greetingRepository.findBySenderAndWalk(command.senderUserId, command.receiverWalkId)
+        if (existing != null) {
+            throw GreetingDuplicateException(command.senderUserId, command.receiverWalkId)
+        }
+
+        val now = Instant.now()
+        val greeting = Greeting(
+            senderUserId = command.senderUserId,
+            senderDogId = command.senderDogId,
+            receiverUserId = walkInfo.userId,
+            receiverDogId = walkInfo.dogId,
+            receiverWalkId = command.receiverWalkId,
+            status = GreetingStatus.PENDING,
+            createdAt = now,
+            expiresAt = now.plusSeconds(300),
+        )
+
+        val saved = greetingRepository.save(greeting)
+        eventPublisher.publishGreetingCreated(saved)
+        return saved
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/application/command/CreateGreetingCommandHandler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/application/command/CreateGreetingCommandHandler.kt
@@ -2,14 +2,13 @@ package com.mungcle.social.application.command
 
 import com.mungcle.social.domain.exception.ForbiddenBlockedException
 import com.mungcle.social.domain.exception.GreetingDuplicateException
+import com.mungcle.social.domain.exception.SelfGreetingException
 import com.mungcle.social.domain.model.Greeting
-import com.mungcle.social.domain.model.GreetingStatus
 import com.mungcle.social.domain.port.`in`.CreateGreetingUseCase
 import com.mungcle.social.domain.port.out.GreetingRepositoryPort
 import com.mungcle.social.domain.port.out.IdentityPort
 import com.mungcle.social.domain.port.out.SocialEventPublisherPort
 import com.mungcle.social.domain.port.out.WalksPort
-import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -22,32 +21,30 @@ class CreateGreetingCommandHandler(
     private val eventPublisher: SocialEventPublisherPort,
 ) : CreateGreetingUseCase {
 
+    override suspend fun execute(command: CreateGreetingUseCase.Command): Greeting {
+        // gRPC 호출 (suspend, 트랜잭션 밖)
+        val walkInfo = walksPort.getWalk(command.receiverWalkId)
+        if (command.senderUserId == walkInfo.userId) throw SelfGreetingException(command.senderUserId)
+        val blocked = identityPort.isBlocked(command.senderUserId, walkInfo.userId)
+        if (blocked) throw ForbiddenBlockedException(command.senderUserId)
+
+        // DB 저장 (트랜잭션)
+        return saveGreeting(command, walkInfo)
+    }
+
     @Transactional
-    override fun execute(command: CreateGreetingUseCase.Command): Greeting {
-        val walkInfo = runBlocking { walksPort.getWalk(command.receiverWalkId) }
-
-        val blocked = runBlocking { identityPort.isBlocked(command.senderUserId, walkInfo.userId) }
-        if (blocked) {
-            throw ForbiddenBlockedException(command.senderUserId)
-        }
-
-        val existing = greetingRepository.findBySenderAndWalk(command.senderUserId, command.receiverWalkId)
-        if (existing != null) {
+    fun saveGreeting(command: CreateGreetingUseCase.Command, walkInfo: WalksPort.WalkInfo): Greeting {
+        greetingRepository.findBySenderAndWalk(command.senderUserId, command.receiverWalkId)?.let {
             throw GreetingDuplicateException(command.senderUserId, command.receiverWalkId)
         }
-
-        val now = Instant.now()
         val greeting = Greeting(
             senderUserId = command.senderUserId,
             senderDogId = command.senderDogId,
             receiverUserId = walkInfo.userId,
             receiverDogId = walkInfo.dogId,
             receiverWalkId = command.receiverWalkId,
-            status = GreetingStatus.PENDING,
-            createdAt = now,
-            expiresAt = now.plusSeconds(300),
+            expiresAt = Instant.now().plusSeconds(300),
         )
-
         val saved = greetingRepository.save(greeting)
         eventPublisher.publishGreetingCreated(saved)
         return saved

--- a/services/social/src/main/kotlin/com/mungcle/social/application/command/RespondGreetingCommandHandler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/application/command/RespondGreetingCommandHandler.kt
@@ -1,0 +1,44 @@
+package com.mungcle.social.application.command
+
+import com.mungcle.social.domain.exception.GreetingAccessDeniedException
+import com.mungcle.social.domain.exception.GreetingExpiredException
+import com.mungcle.social.domain.exception.GreetingNotFoundException
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.port.`in`.RespondGreetingUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class RespondGreetingCommandHandler(
+    private val greetingRepository: GreetingRepositoryPort,
+    private val eventPublisher: SocialEventPublisherPort,
+) : RespondGreetingUseCase {
+
+    @Transactional
+    override fun execute(command: RespondGreetingUseCase.Command): Greeting {
+        val greeting = greetingRepository.findById(command.greetingId)
+            ?: throw GreetingNotFoundException(command.greetingId)
+
+        if (greeting.receiverUserId != command.responderUserId) {
+            throw GreetingAccessDeniedException(command.greetingId)
+        }
+
+        val now = Instant.now()
+        if (greeting.isExpired(now)) {
+            throw GreetingExpiredException(command.greetingId)
+        }
+
+        return if (command.accept) {
+            val accepted = greeting.accept(now)
+            val saved = greetingRepository.save(accepted)
+            eventPublisher.publishGreetingAccepted(saved)
+            saved
+        } else {
+            val expired = greeting.expire()
+            greetingRepository.save(expired)
+        }
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/application/query/GetGreetingQueryHandler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/application/query/GetGreetingQueryHandler.kt
@@ -1,0 +1,25 @@
+package com.mungcle.social.application.query
+
+import com.mungcle.social.domain.exception.GreetingAccessDeniedException
+import com.mungcle.social.domain.exception.GreetingNotFoundException
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.port.`in`.GetGreetingUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class GetGreetingQueryHandler(
+    private val greetingRepository: GreetingRepositoryPort,
+) : GetGreetingUseCase {
+
+    override fun execute(query: GetGreetingUseCase.Query): Greeting {
+        val greeting = greetingRepository.findById(query.greetingId)
+            ?: throw GreetingNotFoundException(query.greetingId)
+
+        if (greeting.senderUserId != query.userId && greeting.receiverUserId != query.userId) {
+            throw GreetingAccessDeniedException(query.greetingId)
+        }
+
+        return greeting
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/application/query/ListGreetingsQueryHandler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/application/query/ListGreetingsQueryHandler.kt
@@ -1,0 +1,20 @@
+package com.mungcle.social.application.query
+
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.port.`in`.ListGreetingsUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class ListGreetingsQueryHandler(
+    private val greetingRepository: GreetingRepositoryPort,
+) : ListGreetingsUseCase {
+
+    override fun execute(query: ListGreetingsUseCase.Query): List<Greeting> {
+        return greetingRepository.findByUserId(
+            userId = query.userId,
+            statusFilter = query.statusFilter,
+            isSender = query.isSender,
+        )
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/exception/SocialExceptions.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/exception/SocialExceptions.kt
@@ -1,0 +1,16 @@
+package com.mungcle.social.domain.exception
+
+sealed class SocialException(message: String) : RuntimeException(message)
+
+class GreetingNotFoundException(id: Long) : SocialException("Greeting $id not found")
+
+class GreetingDuplicateException(senderUserId: Long, receiverWalkId: Long) :
+    SocialException("Duplicate greeting from user $senderUserId to walk $receiverWalkId")
+
+class GreetingExpiredException(id: Long) : SocialException("Greeting $id is expired")
+
+class GreetingNotPendingException(id: Long) : SocialException("Greeting $id is not pending")
+
+class ForbiddenBlockedException(userId: Long) : SocialException("User $userId is blocked")
+
+class GreetingAccessDeniedException(id: Long) : SocialException("Access denied to greeting $id")

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/exception/SocialExceptions.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/exception/SocialExceptions.kt
@@ -13,4 +13,6 @@ class GreetingNotPendingException(id: Long) : SocialException("Greeting $id is n
 
 class ForbiddenBlockedException(userId: Long) : SocialException("User $userId is blocked")
 
+class SelfGreetingException(userId: Long) : SocialException("User $userId cannot greet themselves")
+
 class GreetingAccessDeniedException(id: Long) : SocialException("Access denied to greeting $id")

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/model/Greeting.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/model/Greeting.kt
@@ -1,5 +1,6 @@
 package com.mungcle.social.domain.model
 
+import com.mungcle.social.domain.exception.GreetingNotPendingException
 import java.time.Instant
 
 data class Greeting(
@@ -15,7 +16,7 @@ data class Greeting(
     val expiresAt: Instant,
 ) {
     fun accept(now: Instant): Greeting {
-        check(status == GreetingStatus.PENDING) { "Only PENDING greetings can be accepted" }
+        if (status != GreetingStatus.PENDING) throw GreetingNotPendingException(id)
         return copy(
             status = GreetingStatus.ACCEPTED,
             respondedAt = now,
@@ -23,7 +24,10 @@ data class Greeting(
         )
     }
 
-    fun expire(): Greeting = copy(status = GreetingStatus.EXPIRED)
+    fun expire(): Greeting {
+        if (status != GreetingStatus.PENDING) throw GreetingNotPendingException(id)
+        return copy(status = GreetingStatus.EXPIRED)
+    }
 
     fun isPending(): Boolean = status == GreetingStatus.PENDING
 

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/model/Greeting.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/model/Greeting.kt
@@ -1,0 +1,33 @@
+package com.mungcle.social.domain.model
+
+import java.time.Instant
+
+data class Greeting(
+    val id: Long = 0,
+    val senderUserId: Long,
+    val senderDogId: Long,
+    val receiverUserId: Long,
+    val receiverDogId: Long,
+    val receiverWalkId: Long,
+    val status: GreetingStatus = GreetingStatus.PENDING,
+    val createdAt: Instant = Instant.now(),
+    val respondedAt: Instant? = null,
+    val expiresAt: Instant,
+) {
+    fun accept(now: Instant): Greeting {
+        check(status == GreetingStatus.PENDING) { "Only PENDING greetings can be accepted" }
+        return copy(
+            status = GreetingStatus.ACCEPTED,
+            respondedAt = now,
+            expiresAt = now.plusSeconds(1800),
+        )
+    }
+
+    fun expire(): Greeting = copy(status = GreetingStatus.EXPIRED)
+
+    fun isPending(): Boolean = status == GreetingStatus.PENDING
+
+    fun isAccepted(): Boolean = status == GreetingStatus.ACCEPTED
+
+    fun isExpired(now: Instant): Boolean = now.isAfter(expiresAt)
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/model/GreetingStatus.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/model/GreetingStatus.kt
@@ -1,0 +1,7 @@
+package com.mungcle.social.domain.model
+
+enum class GreetingStatus {
+    PENDING,
+    ACCEPTED,
+    EXPIRED,
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/CreateGreetingUseCase.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/CreateGreetingUseCase.kt
@@ -3,7 +3,7 @@ package com.mungcle.social.domain.port.`in`
 import com.mungcle.social.domain.model.Greeting
 
 interface CreateGreetingUseCase {
-    fun execute(command: Command): Greeting
+    suspend fun execute(command: Command): Greeting
 
     data class Command(
         val senderUserId: Long,

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/CreateGreetingUseCase.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/CreateGreetingUseCase.kt
@@ -1,0 +1,13 @@
+package com.mungcle.social.domain.port.`in`
+
+import com.mungcle.social.domain.model.Greeting
+
+interface CreateGreetingUseCase {
+    fun execute(command: Command): Greeting
+
+    data class Command(
+        val senderUserId: Long,
+        val senderDogId: Long,
+        val receiverWalkId: Long,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/GetGreetingUseCase.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/GetGreetingUseCase.kt
@@ -1,0 +1,12 @@
+package com.mungcle.social.domain.port.`in`
+
+import com.mungcle.social.domain.model.Greeting
+
+interface GetGreetingUseCase {
+    fun execute(query: Query): Greeting
+
+    data class Query(
+        val greetingId: Long,
+        val userId: Long,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/ListGreetingsUseCase.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/ListGreetingsUseCase.kt
@@ -1,0 +1,14 @@
+package com.mungcle.social.domain.port.`in`
+
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+
+interface ListGreetingsUseCase {
+    fun execute(query: Query): List<Greeting>
+
+    data class Query(
+        val userId: Long,
+        val statusFilter: GreetingStatus? = null,
+        val isSender: Boolean? = null,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/RespondGreetingUseCase.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/RespondGreetingUseCase.kt
@@ -1,0 +1,13 @@
+package com.mungcle.social.domain.port.`in`
+
+import com.mungcle.social.domain.model.Greeting
+
+interface RespondGreetingUseCase {
+    fun execute(command: Command): Greeting
+
+    data class Command(
+        val greetingId: Long,
+        val responderUserId: Long,
+        val accept: Boolean,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/GreetingRepositoryPort.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/GreetingRepositoryPort.kt
@@ -1,0 +1,22 @@
+package com.mungcle.social.domain.port.out
+
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+
+/**
+ * Greeting 영속성 포트.
+ * 인프라 레이어에서 구현한다.
+ */
+interface GreetingRepositoryPort {
+    /** Greeting을 저장하고 저장된 Greeting을 반환한다. */
+    fun save(greeting: Greeting): Greeting
+
+    /** ID로 Greeting을 조회한다. 없으면 null. */
+    fun findById(id: Long): Greeting?
+
+    /** 동일 발신자-산책 조합의 Greeting을 조회한다. 중복 방지에 사용. */
+    fun findBySenderAndWalk(senderUserId: Long, receiverWalkId: Long): Greeting?
+
+    /** 사용자 ID와 선택적 필터로 Greeting 목록을 조회한다. */
+    fun findByUserId(userId: Long, statusFilter: GreetingStatus?, isSender: Boolean?): List<Greeting>
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/IdentityPort.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/IdentityPort.kt
@@ -1,0 +1,13 @@
+package com.mungcle.social.domain.port.out
+
+/**
+ * Identity 서비스와의 통신 포트.
+ * 차단 여부 등 identity 관련 기능을 제공한다.
+ */
+interface IdentityPort {
+    /**
+     * 두 사용자 사이에 차단 관계가 있는지 확인한다.
+     * @return 한쪽이라도 상대를 차단했으면 true
+     */
+    suspend fun isBlocked(userId1: Long, userId2: Long): Boolean
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/SocialEventPublisherPort.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/SocialEventPublisherPort.kt
@@ -1,0 +1,15 @@
+package com.mungcle.social.domain.port.out
+
+import com.mungcle.social.domain.model.Greeting
+
+/**
+ * 소셜 이벤트 발행 포트.
+ * Kafka 등 메시지 브로커로 이벤트를 발행한다.
+ */
+interface SocialEventPublisherPort {
+    /** 인사 생성 이벤트를 발행한다. */
+    fun publishGreetingCreated(greeting: Greeting)
+
+    /** 인사 수락 이벤트를 발행한다. */
+    fun publishGreetingAccepted(greeting: Greeting)
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/WalksPort.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/WalksPort.kt
@@ -1,0 +1,19 @@
+package com.mungcle.social.domain.port.out
+
+/**
+ * Walks 서비스와의 통신 포트.
+ * 산책 정보 조회 기능을 제공한다.
+ */
+interface WalksPort {
+    /**
+     * 산책 ID로 산책 참여자 정보를 조회한다.
+     * @throws com.mungcle.social.domain.exception.GreetingNotFoundException 산책을 찾을 수 없을 때
+     */
+    suspend fun getWalk(walkId: Long): WalkInfo
+
+    data class WalkInfo(
+        val walkId: Long,
+        val userId: Long,
+        val dogId: Long,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/client/IdentityGrpcClient.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/client/IdentityGrpcClient.kt
@@ -1,0 +1,22 @@
+package com.mungcle.social.infrastructure.grpc.client
+
+import com.mungcle.proto.identity.v1.IdentityServiceGrpcKt
+import com.mungcle.proto.identity.v1.isBlockedRequest
+import com.mungcle.social.domain.port.out.IdentityPort
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.springframework.stereotype.Component
+
+@Component
+class IdentityGrpcClient(
+    @GrpcClient("identity")
+    private val stub: IdentityServiceGrpcKt.IdentityServiceCoroutineStub,
+) : IdentityPort {
+
+    override suspend fun isBlocked(userId1: Long, userId2: Long): Boolean {
+        val request = isBlockedRequest {
+            userIdA = userId1
+            userIdB = userId2
+        }
+        return stub.isBlocked(request).blocked
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/client/WalksGrpcClient.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/client/WalksGrpcClient.kt
@@ -1,0 +1,20 @@
+package com.mungcle.social.infrastructure.grpc.client
+
+import com.mungcle.social.domain.port.out.WalksPort
+import org.springframework.stereotype.Component
+
+/**
+ * WalksPort stub 구현체.
+ * walks proto에 단건 Walk 조회 RPC가 없으므로 태스크 08에서 완성 예정.
+ * 현재는 GreetingNotFoundException을 던지는 stub으로 대체한다.
+ */
+@Component
+class WalksGrpcClient : WalksPort {
+
+    override suspend fun getWalk(walkId: Long): WalksPort.WalkInfo {
+        throw UnsupportedOperationException(
+            "WalksGrpcClient.getWalk is not yet implemented — walks proto lacks a GetWalk RPC. " +
+                "Implement in task-08 when GetWalk is added to walks.proto."
+        )
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialExceptionExtensions.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialExceptionExtensions.kt
@@ -1,0 +1,20 @@
+package com.mungcle.social.infrastructure.grpc.server
+
+import com.mungcle.social.domain.exception.ForbiddenBlockedException
+import com.mungcle.social.domain.exception.GreetingAccessDeniedException
+import com.mungcle.social.domain.exception.GreetingDuplicateException
+import com.mungcle.social.domain.exception.GreetingExpiredException
+import com.mungcle.social.domain.exception.GreetingNotFoundException
+import com.mungcle.social.domain.exception.GreetingNotPendingException
+import com.mungcle.social.domain.exception.SocialException
+import io.grpc.Status
+import io.grpc.StatusException
+
+fun SocialException.toStatusException(): StatusException = when (this) {
+    is GreetingNotFoundException -> StatusException(Status.NOT_FOUND.withDescription(message))
+    is GreetingDuplicateException -> StatusException(Status.ALREADY_EXISTS.withDescription(message))
+    is GreetingExpiredException -> StatusException(Status.FAILED_PRECONDITION.withDescription(message))
+    is GreetingNotPendingException -> StatusException(Status.FAILED_PRECONDITION.withDescription(message))
+    is ForbiddenBlockedException -> StatusException(Status.PERMISSION_DENIED.withDescription(message))
+    is GreetingAccessDeniedException -> StatusException(Status.PERMISSION_DENIED.withDescription(message))
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialExceptionExtensions.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialExceptionExtensions.kt
@@ -6,6 +6,7 @@ import com.mungcle.social.domain.exception.GreetingDuplicateException
 import com.mungcle.social.domain.exception.GreetingExpiredException
 import com.mungcle.social.domain.exception.GreetingNotFoundException
 import com.mungcle.social.domain.exception.GreetingNotPendingException
+import com.mungcle.social.domain.exception.SelfGreetingException
 import com.mungcle.social.domain.exception.SocialException
 import io.grpc.Status
 import io.grpc.StatusException
@@ -17,4 +18,5 @@ fun SocialException.toStatusException(): StatusException = when (this) {
     is GreetingNotPendingException -> StatusException(Status.FAILED_PRECONDITION.withDescription(message))
     is ForbiddenBlockedException -> StatusException(Status.PERMISSION_DENIED.withDescription(message))
     is GreetingAccessDeniedException -> StatusException(Status.PERMISSION_DENIED.withDescription(message))
+    is SelfGreetingException -> StatusException(Status.INVALID_ARGUMENT.withDescription(message))
 }

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialGrpcService.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialGrpcService.kt
@@ -1,0 +1,139 @@
+package com.mungcle.social.infrastructure.grpc.server
+
+import com.mungcle.proto.social.v1.CreateGreetingRequest
+import com.mungcle.proto.social.v1.GetGreetingRequest
+import com.mungcle.proto.social.v1.GreetingInfo
+import com.mungcle.proto.social.v1.GreetingStatus as ProtoGreetingStatus
+import com.mungcle.proto.social.v1.GreetingDirection
+import com.mungcle.proto.social.v1.ListGreetingsRequest
+import com.mungcle.proto.social.v1.ListGreetingsResponse
+import com.mungcle.proto.social.v1.ListMessagesRequest
+import com.mungcle.proto.social.v1.ListMessagesResponse
+import com.mungcle.proto.social.v1.RespondGreetingRequest
+import com.mungcle.proto.social.v1.SendMessageRequest
+import com.mungcle.proto.social.v1.MessageInfo
+import com.mungcle.proto.social.v1.SocialServiceGrpcKt
+import com.mungcle.proto.social.v1.greetingInfo
+import com.mungcle.proto.social.v1.listGreetingsResponse
+import com.mungcle.social.domain.exception.SocialException
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.port.`in`.CreateGreetingUseCase
+import com.mungcle.social.domain.port.`in`.GetGreetingUseCase
+import com.mungcle.social.domain.port.`in`.ListGreetingsUseCase
+import com.mungcle.social.domain.port.`in`.RespondGreetingUseCase
+import io.grpc.Status
+import io.grpc.StatusException
+import net.devh.boot.grpc.server.service.GrpcService
+
+@GrpcService
+class SocialGrpcService(
+    private val createGreetingUseCase: CreateGreetingUseCase,
+    private val respondGreetingUseCase: RespondGreetingUseCase,
+    private val getGreetingUseCase: GetGreetingUseCase,
+    private val listGreetingsUseCase: ListGreetingsUseCase,
+) : SocialServiceGrpcKt.SocialServiceCoroutineImplBase() {
+
+    override suspend fun createGreeting(request: CreateGreetingRequest): GreetingInfo {
+        try {
+            val greeting = createGreetingUseCase.execute(
+                CreateGreetingUseCase.Command(
+                    senderUserId = request.senderUserId,
+                    senderDogId = request.senderDogId,
+                    receiverWalkId = request.receiverWalkId,
+                )
+            )
+            return greeting.toGreetingInfo()
+        } catch (e: SocialException) {
+            throw e.toStatusException()
+        }
+    }
+
+    override suspend fun respondGreeting(request: RespondGreetingRequest): GreetingInfo {
+        try {
+            val greeting = respondGreetingUseCase.execute(
+                RespondGreetingUseCase.Command(
+                    greetingId = request.greetingId,
+                    responderUserId = request.responderUserId,
+                    accept = request.accept,
+                )
+            )
+            return greeting.toGreetingInfo()
+        } catch (e: SocialException) {
+            throw e.toStatusException()
+        }
+    }
+
+    override suspend fun getGreeting(request: GetGreetingRequest): GreetingInfo {
+        try {
+            val greeting = getGreetingUseCase.execute(
+                GetGreetingUseCase.Query(
+                    greetingId = request.greetingId,
+                    userId = request.userId,
+                )
+            )
+            return greeting.toGreetingInfo()
+        } catch (e: SocialException) {
+            throw e.toStatusException()
+        }
+    }
+
+    override suspend fun listGreetings(request: ListGreetingsRequest): ListGreetingsResponse {
+        try {
+            val statusFilter = when {
+                request.hasStatusFilter() -> request.statusFilter.toDomain()
+                else -> null
+            }
+            val isSender = when {
+                request.hasDirectionFilter() -> request.directionFilter == GreetingDirection.GREETING_DIRECTION_SENT
+                else -> null
+            }
+            val greetings = listGreetingsUseCase.execute(
+                ListGreetingsUseCase.Query(
+                    userId = request.userId,
+                    statusFilter = statusFilter,
+                    isSender = isSender,
+                )
+            )
+            return listGreetingsResponse {
+                this.greetings += greetings.map { it.toGreetingInfo() }
+            }
+        } catch (e: SocialException) {
+            throw e.toStatusException()
+        }
+    }
+
+    override suspend fun sendMessage(request: SendMessageRequest): MessageInfo {
+        throw StatusException(Status.UNIMPLEMENTED.withDescription("태스크 08에서 구현 예정"))
+    }
+
+    override suspend fun listMessages(request: ListMessagesRequest): ListMessagesResponse {
+        throw StatusException(Status.UNIMPLEMENTED.withDescription("태스크 08에서 구현 예정"))
+    }
+
+    private fun Greeting.toGreetingInfo(): GreetingInfo = greetingInfo {
+        id = this@toGreetingInfo.id
+        senderUserId = this@toGreetingInfo.senderUserId
+        receiverUserId = this@toGreetingInfo.receiverUserId
+        senderDogId = this@toGreetingInfo.senderDogId
+        receiverDogId = this@toGreetingInfo.receiverDogId
+        receiverWalkId = this@toGreetingInfo.receiverWalkId
+        status = this@toGreetingInfo.status.toProto()
+        createdAt = this@toGreetingInfo.createdAt.epochSecond
+        this@toGreetingInfo.respondedAt?.let { respondedAt = it.epochSecond }
+        this@toGreetingInfo.expiresAt.let { expiresAt = it.epochSecond }
+    }
+
+    private fun GreetingStatus.toProto(): ProtoGreetingStatus = when (this) {
+        GreetingStatus.PENDING -> ProtoGreetingStatus.GREETING_STATUS_PENDING
+        GreetingStatus.ACCEPTED -> ProtoGreetingStatus.GREETING_STATUS_ACCEPTED
+        GreetingStatus.EXPIRED -> ProtoGreetingStatus.GREETING_STATUS_EXPIRED
+    }
+
+    private fun ProtoGreetingStatus.toDomain(): GreetingStatus? = when (this) {
+        ProtoGreetingStatus.GREETING_STATUS_PENDING -> GreetingStatus.PENDING
+        ProtoGreetingStatus.GREETING_STATUS_ACCEPTED -> GreetingStatus.ACCEPTED
+        ProtoGreetingStatus.GREETING_STATUS_EXPIRED -> GreetingStatus.EXPIRED
+        else -> null
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/kafka/SocialEventPublisher.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/kafka/SocialEventPublisher.kt
@@ -1,0 +1,33 @@
+package com.mungcle.social.infrastructure.kafka
+
+import com.mungcle.common.kafka.GreetingAcceptedEvent
+import com.mungcle.common.kafka.GreetingCreatedEvent
+import com.mungcle.common.kafka.Topics
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class SocialEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, Any>,
+) : SocialEventPublisherPort {
+
+    override fun publishGreetingCreated(greeting: Greeting) {
+        val event = GreetingCreatedEvent(
+            greetingId = greeting.id,
+            senderUserId = greeting.senderUserId,
+            receiverUserId = greeting.receiverUserId,
+        )
+        kafkaTemplate.send(Topics.GREETING_CREATED, greeting.id.toString(), event)
+    }
+
+    override fun publishGreetingAccepted(greeting: Greeting) {
+        val event = GreetingAcceptedEvent(
+            greetingId = greeting.id,
+            senderUserId = greeting.senderUserId,
+            receiverUserId = greeting.receiverUserId,
+        )
+        kafkaTemplate.send(Topics.GREETING_ACCEPTED, greeting.id.toString(), event)
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingEntity.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingEntity.kt
@@ -38,7 +38,7 @@ open class GreetingEntity(
     open var receiverWalkId: Long = 0,
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 20)
     open var status: GreetingStatus = GreetingStatus.PENDING,
 
     @Column(name = "created_at", nullable = false)

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingEntity.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingEntity.kt
@@ -1,0 +1,52 @@
+package com.mungcle.social.infrastructure.persistence
+
+import com.mungcle.social.domain.model.GreetingStatus
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "greetings",
+    schema = "social",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["sender_user_id", "receiver_walk_id"])],
+)
+open class GreetingEntity(
+    @Id
+    @Tsid
+    open var id: Long = 0,
+
+    @Column(name = "sender_user_id", nullable = false)
+    open var senderUserId: Long = 0,
+
+    @Column(name = "sender_dog_id", nullable = false)
+    open var senderDogId: Long = 0,
+
+    @Column(name = "receiver_user_id", nullable = false)
+    open var receiverUserId: Long = 0,
+
+    @Column(name = "receiver_dog_id", nullable = false)
+    open var receiverDogId: Long = 0,
+
+    @Column(name = "receiver_walk_id", nullable = false)
+    open var receiverWalkId: Long = 0,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    open var status: GreetingStatus = GreetingStatus.PENDING,
+
+    @Column(name = "created_at", nullable = false)
+    open var createdAt: Instant = Instant.now(),
+
+    @Column(name = "responded_at")
+    open var respondedAt: Instant? = null,
+
+    @Column(name = "expires_at", nullable = false)
+    open var expiresAt: Instant = Instant.now(),
+)

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingMapper.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingMapper.kt
@@ -1,0 +1,32 @@
+package com.mungcle.social.infrastructure.persistence
+
+import com.mungcle.social.domain.model.Greeting
+
+object GreetingMapper {
+
+    fun toDomain(entity: GreetingEntity): Greeting = Greeting(
+        id = entity.id,
+        senderUserId = entity.senderUserId,
+        senderDogId = entity.senderDogId,
+        receiverUserId = entity.receiverUserId,
+        receiverDogId = entity.receiverDogId,
+        receiverWalkId = entity.receiverWalkId,
+        status = entity.status,
+        createdAt = entity.createdAt,
+        respondedAt = entity.respondedAt,
+        expiresAt = entity.expiresAt,
+    )
+
+    fun toEntity(domain: Greeting): GreetingEntity = GreetingEntity(
+        id = domain.id,
+        senderUserId = domain.senderUserId,
+        senderDogId = domain.senderDogId,
+        receiverUserId = domain.receiverUserId,
+        receiverDogId = domain.receiverDogId,
+        receiverWalkId = domain.receiverWalkId,
+        status = domain.status,
+        createdAt = domain.createdAt,
+        respondedAt = domain.respondedAt,
+        expiresAt = domain.expiresAt,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingRepositoryAdapter.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingRepositoryAdapter.kt
@@ -1,0 +1,29 @@
+package com.mungcle.social.infrastructure.persistence
+
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class GreetingRepositoryAdapter(
+    private val springDataRepository: GreetingSpringDataRepository,
+) : GreetingRepositoryPort {
+
+    override fun save(greeting: Greeting): Greeting {
+        val entity = GreetingMapper.toEntity(greeting)
+        val saved = springDataRepository.save(entity)
+        return GreetingMapper.toDomain(saved)
+    }
+
+    override fun findById(id: Long): Greeting? =
+        springDataRepository.findById(id).orElse(null)?.let(GreetingMapper::toDomain)
+
+    override fun findBySenderAndWalk(senderUserId: Long, receiverWalkId: Long): Greeting? =
+        springDataRepository.findBySenderAndWalk(senderUserId, receiverWalkId)
+            .orElse(null)?.let(GreetingMapper::toDomain)
+
+    override fun findByUserId(userId: Long, statusFilter: GreetingStatus?, isSender: Boolean?): List<Greeting> =
+        springDataRepository.findByUserId(userId, statusFilter, isSender)
+            .map(GreetingMapper::toDomain)
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingSpringDataRepository.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingSpringDataRepository.kt
@@ -1,0 +1,32 @@
+package com.mungcle.social.infrastructure.persistence
+
+import com.mungcle.social.domain.model.GreetingStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.Optional
+
+interface GreetingSpringDataRepository : JpaRepository<GreetingEntity, Long> {
+
+    @Query(
+        "SELECT g FROM GreetingEntity g WHERE g.senderUserId = :senderUserId AND g.receiverWalkId = :receiverWalkId"
+    )
+    fun findBySenderAndWalk(
+        @Param("senderUserId") senderUserId: Long,
+        @Param("receiverWalkId") receiverWalkId: Long,
+    ): Optional<GreetingEntity>
+
+    @Query(
+        """SELECT g FROM GreetingEntity g
+           WHERE (g.senderUserId = :userId OR g.receiverUserId = :userId)
+             AND (:statusFilter IS NULL OR g.status = :statusFilter)
+             AND (:isSender IS NULL
+                  OR (:isSender = TRUE AND g.senderUserId = :userId)
+                  OR (:isSender = FALSE AND g.receiverUserId = :userId))"""
+    )
+    fun findByUserId(
+        @Param("userId") userId: Long,
+        @Param("statusFilter") statusFilter: GreetingStatus?,
+        @Param("isSender") isSender: Boolean?,
+    ): List<GreetingEntity>
+}

--- a/services/social/src/main/resources/db/migration/V1__init_social_schema.sql
+++ b/services/social/src/main/resources/db/migration/V1__init_social_schema.sql
@@ -2,29 +2,17 @@ CREATE SCHEMA IF NOT EXISTS social;
 SET search_path TO social;
 
 CREATE TABLE greetings (
-    id                  BIGINT PRIMARY KEY,
-    sender_user_id      BIGINT NOT NULL,
-    receiver_user_id    BIGINT NOT NULL,
-    sender_dog_id       BIGINT NOT NULL,
-    receiver_dog_id     BIGINT,
-    receiver_walk_id    BIGINT NOT NULL,
-    status              VARCHAR(10) NOT NULL DEFAULT 'PENDING', -- PENDING, ACCEPTED, EXPIRED
-    created_at          TIMESTAMP NOT NULL DEFAULT NOW(),
-    responded_at        TIMESTAMP,
-    expires_at          TIMESTAMP NOT NULL,
-    UNIQUE(sender_user_id, receiver_user_id, receiver_walk_id)
+    id                BIGINT PRIMARY KEY,
+    sender_user_id    BIGINT NOT NULL,
+    sender_dog_id     BIGINT NOT NULL,
+    receiver_user_id  BIGINT NOT NULL,
+    receiver_dog_id   BIGINT NOT NULL,
+    receiver_walk_id  BIGINT NOT NULL,
+    status            VARCHAR(10) NOT NULL DEFAULT 'PENDING',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    responded_at      TIMESTAMPTZ,
+    expires_at        TIMESTAMPTZ NOT NULL,
+    UNIQUE (sender_user_id, receiver_walk_id)
 );
-
-CREATE INDEX idx_greetings_receiver ON greetings(receiver_user_id, status);
-CREATE INDEX idx_greetings_sender ON greetings(sender_user_id, status);
-CREATE INDEX idx_greetings_expiry ON greetings(status, expires_at) WHERE status IN ('PENDING', 'ACCEPTED');
-
-CREATE TABLE messages (
-    id              BIGINT PRIMARY KEY,
-    greeting_id     BIGINT NOT NULL REFERENCES greetings(id),
-    sender_user_id  BIGINT NOT NULL,
-    body            VARCHAR(140) NOT NULL,
-    created_at      TIMESTAMP NOT NULL DEFAULT NOW()
-);
-
-CREATE INDEX idx_messages_greeting ON messages(greeting_id, created_at);
+CREATE INDEX idx_greetings_receiver ON greetings (receiver_user_id, status);
+CREATE INDEX idx_greetings_sender ON greetings (sender_user_id, status);

--- a/services/social/src/main/resources/db/migration/V1__init_social_schema.sql
+++ b/services/social/src/main/resources/db/migration/V1__init_social_schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE greetings (
     receiver_user_id  BIGINT NOT NULL,
     receiver_dog_id   BIGINT NOT NULL,
     receiver_walk_id  BIGINT NOT NULL,
-    status            VARCHAR(10) NOT NULL DEFAULT 'PENDING',
+    status            VARCHAR(20) NOT NULL DEFAULT 'PENDING',
     created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     responded_at      TIMESTAMPTZ,
     expires_at        TIMESTAMPTZ NOT NULL,

--- a/services/social/src/test/kotlin/com/mungcle/social/application/command/CreateGreetingCommandHandlerTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/application/command/CreateGreetingCommandHandlerTest.kt
@@ -2,6 +2,7 @@ package com.mungcle.social.application.command
 
 import com.mungcle.social.domain.exception.ForbiddenBlockedException
 import com.mungcle.social.domain.exception.GreetingDuplicateException
+import com.mungcle.social.domain.exception.SelfGreetingException
 import com.mungcle.social.domain.model.Greeting
 import com.mungcle.social.domain.model.GreetingStatus
 import com.mungcle.social.domain.port.`in`.CreateGreetingUseCase
@@ -43,7 +44,7 @@ class CreateGreetingCommandHandlerTest {
     private val walkInfo = WalksPort.WalkInfo(walkId = 300L, userId = 20L, dogId = 200L)
 
     @Test
-    fun `정상 인사 생성`() {
+    fun `정상 인사 생성`() = runTest {
         coEvery { walksPort.getWalk(300L) } returns walkInfo
         coEvery { identityPort.isBlocked(10L, 20L) } returns false
         every { greetingRepository.findBySenderAndWalk(10L, 300L) } returns null
@@ -62,16 +63,14 @@ class CreateGreetingCommandHandlerTest {
     }
 
     @Test
-    fun `expiresAt은 생성 시각으로부터 5분 후`() {
+    fun `expiresAt은 생성 시각으로부터 5분 후`() = runTest {
         coEvery { walksPort.getWalk(300L) } returns walkInfo
         coEvery { identityPort.isBlocked(10L, 20L) } returns false
         every { greetingRepository.findBySenderAndWalk(10L, 300L) } returns null
         val slot = slot<Greeting>()
         every { greetingRepository.save(capture(slot)) } answers { slot.captured.copy(id = 1L) }
 
-        val before = Instant.now()
         handler.execute(command)
-        val after = Instant.now()
 
         val saved = slot.captured
         val secondsUntilExpiry = saved.expiresAt.epochSecond - saved.createdAt.epochSecond
@@ -79,7 +78,7 @@ class CreateGreetingCommandHandlerTest {
     }
 
     @Test
-    fun `차단된 사용자 → ForbiddenBlockedException`() {
+    fun `차단된 사용자 → ForbiddenBlockedException`() = runTest {
         coEvery { walksPort.getWalk(300L) } returns walkInfo
         coEvery { identityPort.isBlocked(10L, 20L) } returns true
 
@@ -89,7 +88,7 @@ class CreateGreetingCommandHandlerTest {
     }
 
     @Test
-    fun `중복 인사 → GreetingDuplicateException`() {
+    fun `중복 인사 → GreetingDuplicateException`() = runTest {
         coEvery { walksPort.getWalk(300L) } returns walkInfo
         coEvery { identityPort.isBlocked(10L, 20L) } returns false
         val existing = Greeting(
@@ -105,6 +104,16 @@ class CreateGreetingCommandHandlerTest {
         every { greetingRepository.findBySenderAndWalk(10L, 300L) } returns existing
 
         assertThrows<GreetingDuplicateException> {
+            handler.execute(command)
+        }
+    }
+
+    @Test
+    fun `자기 자신에게 인사 → SelfGreetingException`() = runTest {
+        val selfWalkInfo = WalksPort.WalkInfo(walkId = 300L, userId = 10L, dogId = 100L)
+        coEvery { walksPort.getWalk(300L) } returns selfWalkInfo
+
+        assertThrows<SelfGreetingException> {
             handler.execute(command)
         }
     }

--- a/services/social/src/test/kotlin/com/mungcle/social/application/command/CreateGreetingCommandHandlerTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/application/command/CreateGreetingCommandHandlerTest.kt
@@ -1,0 +1,111 @@
+package com.mungcle.social.application.command
+
+import com.mungcle.social.domain.exception.ForbiddenBlockedException
+import com.mungcle.social.domain.exception.GreetingDuplicateException
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.port.`in`.CreateGreetingUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.IdentityPort
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import com.mungcle.social.domain.port.out.WalksPort
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class CreateGreetingCommandHandlerTest {
+
+    private val greetingRepository: GreetingRepositoryPort = mockk()
+    private val identityPort: IdentityPort = mockk()
+    private val walksPort: WalksPort = mockk()
+    private val eventPublisher: SocialEventPublisherPort = mockk(relaxed = true)
+
+    private val handler = CreateGreetingCommandHandler(
+        greetingRepository = greetingRepository,
+        identityPort = identityPort,
+        walksPort = walksPort,
+        eventPublisher = eventPublisher,
+    )
+
+    private val command = CreateGreetingUseCase.Command(
+        senderUserId = 10L,
+        senderDogId = 100L,
+        receiverWalkId = 300L,
+    )
+
+    private val walkInfo = WalksPort.WalkInfo(walkId = 300L, userId = 20L, dogId = 200L)
+
+    @Test
+    fun `정상 인사 생성`() {
+        coEvery { walksPort.getWalk(300L) } returns walkInfo
+        coEvery { identityPort.isBlocked(10L, 20L) } returns false
+        every { greetingRepository.findBySenderAndWalk(10L, 300L) } returns null
+        val slot = slot<Greeting>()
+        every { greetingRepository.save(capture(slot)) } answers {
+            slot.captured.copy(id = 1L)
+        }
+
+        val result = handler.execute(command)
+
+        assertEquals(1L, result.id)
+        assertEquals(10L, result.senderUserId)
+        assertEquals(20L, result.receiverUserId)
+        assertEquals(GreetingStatus.PENDING, result.status)
+        verify { eventPublisher.publishGreetingCreated(any()) }
+    }
+
+    @Test
+    fun `expiresAt은 생성 시각으로부터 5분 후`() {
+        coEvery { walksPort.getWalk(300L) } returns walkInfo
+        coEvery { identityPort.isBlocked(10L, 20L) } returns false
+        every { greetingRepository.findBySenderAndWalk(10L, 300L) } returns null
+        val slot = slot<Greeting>()
+        every { greetingRepository.save(capture(slot)) } answers { slot.captured.copy(id = 1L) }
+
+        val before = Instant.now()
+        handler.execute(command)
+        val after = Instant.now()
+
+        val saved = slot.captured
+        val secondsUntilExpiry = saved.expiresAt.epochSecond - saved.createdAt.epochSecond
+        assert(secondsUntilExpiry in 299..301) { "expiresAt should be ~300s after createdAt, was $secondsUntilExpiry" }
+    }
+
+    @Test
+    fun `차단된 사용자 → ForbiddenBlockedException`() {
+        coEvery { walksPort.getWalk(300L) } returns walkInfo
+        coEvery { identityPort.isBlocked(10L, 20L) } returns true
+
+        assertThrows<ForbiddenBlockedException> {
+            handler.execute(command)
+        }
+    }
+
+    @Test
+    fun `중복 인사 → GreetingDuplicateException`() {
+        coEvery { walksPort.getWalk(300L) } returns walkInfo
+        coEvery { identityPort.isBlocked(10L, 20L) } returns false
+        val existing = Greeting(
+            id = 99L,
+            senderUserId = 10L,
+            senderDogId = 100L,
+            receiverUserId = 20L,
+            receiverDogId = 200L,
+            receiverWalkId = 300L,
+            status = GreetingStatus.PENDING,
+            expiresAt = Instant.now().plusSeconds(300),
+        )
+        every { greetingRepository.findBySenderAndWalk(10L, 300L) } returns existing
+
+        assertThrows<GreetingDuplicateException> {
+            handler.execute(command)
+        }
+    }
+}

--- a/services/social/src/test/kotlin/com/mungcle/social/application/command/RespondGreetingCommandHandlerTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/application/command/RespondGreetingCommandHandlerTest.kt
@@ -1,0 +1,96 @@
+package com.mungcle.social.application.command
+
+import com.mungcle.social.domain.exception.GreetingAccessDeniedException
+import com.mungcle.social.domain.exception.GreetingExpiredException
+import com.mungcle.social.domain.exception.GreetingNotFoundException
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.port.`in`.RespondGreetingUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class RespondGreetingCommandHandlerTest {
+
+    private val greetingRepository: GreetingRepositoryPort = mockk()
+    private val eventPublisher: SocialEventPublisherPort = mockk(relaxed = true)
+
+    private val handler = RespondGreetingCommandHandler(
+        greetingRepository = greetingRepository,
+        eventPublisher = eventPublisher,
+    )
+
+    private fun pendingGreeting(
+        id: Long = 1L,
+        receiverUserId: Long = 20L,
+        expiresAt: Instant = Instant.now().plusSeconds(300),
+    ) = Greeting(
+        id = id,
+        senderUserId = 10L,
+        senderDogId = 100L,
+        receiverUserId = receiverUserId,
+        receiverDogId = 200L,
+        receiverWalkId = 300L,
+        status = GreetingStatus.PENDING,
+        expiresAt = expiresAt,
+    )
+
+    @Test
+    fun `수락 — ACCEPTED 상태로 전이되고 이벤트 발행`() {
+        val greeting = pendingGreeting()
+        every { greetingRepository.findById(1L) } returns greeting
+        every { greetingRepository.save(any()) } answers { firstArg() }
+
+        val result = handler.execute(RespondGreetingUseCase.Command(1L, 20L, accept = true))
+
+        assertEquals(GreetingStatus.ACCEPTED, result.status)
+        verify { eventPublisher.publishGreetingAccepted(any()) }
+    }
+
+    @Test
+    fun `거절 — EXPIRED 상태로 전이, 이벤트 없음`() {
+        val greeting = pendingGreeting()
+        every { greetingRepository.findById(1L) } returns greeting
+        every { greetingRepository.save(any()) } answers { firstArg() }
+
+        val result = handler.execute(RespondGreetingUseCase.Command(1L, 20L, accept = false))
+
+        assertEquals(GreetingStatus.EXPIRED, result.status)
+        verify(exactly = 0) { eventPublisher.publishGreetingAccepted(any()) }
+    }
+
+    @Test
+    fun `존재하지 않는 인사 → GreetingNotFoundException`() {
+        every { greetingRepository.findById(99L) } returns null
+
+        assertThrows<GreetingNotFoundException> {
+            handler.execute(RespondGreetingUseCase.Command(99L, 20L, accept = true))
+        }
+    }
+
+    @Test
+    fun `만료된 인사 → GreetingExpiredException`() {
+        val expired = pendingGreeting(expiresAt = Instant.now().minusSeconds(1))
+        every { greetingRepository.findById(1L) } returns expired
+
+        assertThrows<GreetingExpiredException> {
+            handler.execute(RespondGreetingUseCase.Command(1L, 20L, accept = true))
+        }
+    }
+
+    @Test
+    fun `수신자가 아닌 사용자 응답 → GreetingAccessDeniedException`() {
+        val greeting = pendingGreeting(receiverUserId = 20L)
+        every { greetingRepository.findById(1L) } returns greeting
+
+        assertThrows<GreetingAccessDeniedException> {
+            handler.execute(RespondGreetingUseCase.Command(1L, responderUserId = 99L, accept = true))
+        }
+    }
+}

--- a/services/social/src/test/kotlin/com/mungcle/social/domain/model/GreetingTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/domain/model/GreetingTest.kt
@@ -1,0 +1,90 @@
+package com.mungcle.social.domain.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GreetingTest {
+
+    private fun pendingGreeting(
+        id: Long = 1L,
+        expiresAt: Instant = Instant.now().plusSeconds(300),
+    ) = Greeting(
+        id = id,
+        senderUserId = 10L,
+        senderDogId = 100L,
+        receiverUserId = 20L,
+        receiverDogId = 200L,
+        receiverWalkId = 300L,
+        status = GreetingStatus.PENDING,
+        expiresAt = expiresAt,
+    )
+
+    @Test
+    fun `isPending — PENDING 상태이면 true`() {
+        assertTrue(pendingGreeting().isPending())
+    }
+
+    @Test
+    fun `isPending — ACCEPTED 상태이면 false`() {
+        val greeting = pendingGreeting().accept(Instant.now())
+        assertFalse(greeting.isPending())
+    }
+
+    @Test
+    fun `isAccepted — accept 후 true`() {
+        val greeting = pendingGreeting().accept(Instant.now())
+        assertTrue(greeting.isAccepted())
+    }
+
+    @Test
+    fun `accept — PENDING에서 ACCEPTED로 상태 전이`() {
+        val now = Instant.now()
+        val accepted = pendingGreeting().accept(now)
+
+        assertEquals(GreetingStatus.ACCEPTED, accepted.status)
+        assertEquals(now, accepted.respondedAt)
+    }
+
+    @Test
+    fun `accept — expiresAt은 respondedAt으로부터 30분 후`() {
+        val now = Instant.now()
+        val accepted = pendingGreeting().accept(now)
+
+        val diff = Duration.between(now, accepted.expiresAt)
+        assertEquals(1800, diff.seconds)
+    }
+
+    @Test
+    fun `accept — PENDING이 아니면 IllegalStateException`() {
+        val accepted = pendingGreeting().accept(Instant.now())
+
+        assertThrows<IllegalStateException> {
+            accepted.accept(Instant.now())
+        }
+    }
+
+    @Test
+    fun `expire — EXPIRED 상태로 전이`() {
+        val expired = pendingGreeting().expire()
+        assertEquals(GreetingStatus.EXPIRED, expired.status)
+    }
+
+    @Test
+    fun `isExpired — expiresAt 이후이면 true`() {
+        val past = Instant.now().minusSeconds(1)
+        val greeting = pendingGreeting(expiresAt = past)
+        assertTrue(greeting.isExpired(Instant.now()))
+    }
+
+    @Test
+    fun `isExpired — expiresAt 이전이면 false`() {
+        val future = Instant.now().plusSeconds(300)
+        val greeting = pendingGreeting(expiresAt = future)
+        assertFalse(greeting.isExpired(Instant.now()))
+    }
+}

--- a/services/social/src/test/kotlin/com/mungcle/social/domain/model/GreetingTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/domain/model/GreetingTest.kt
@@ -1,5 +1,6 @@
 package com.mungcle.social.domain.model
 
+import com.mungcle.social.domain.exception.GreetingNotPendingException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.Duration
@@ -60,10 +61,10 @@ class GreetingTest {
     }
 
     @Test
-    fun `accept — PENDING이 아니면 IllegalStateException`() {
+    fun `accept — PENDING이 아니면 GreetingNotPendingException`() {
         val accepted = pendingGreeting().accept(Instant.now())
 
-        assertThrows<IllegalStateException> {
+        assertThrows<GreetingNotPendingException> {
             accepted.accept(Instant.now())
         }
     }
@@ -72,6 +73,15 @@ class GreetingTest {
     fun `expire — EXPIRED 상태로 전이`() {
         val expired = pendingGreeting().expire()
         assertEquals(GreetingStatus.EXPIRED, expired.status)
+    }
+
+    @Test
+    fun `expire — PENDING이 아니면 GreetingNotPendingException`() {
+        val accepted = pendingGreeting().accept(Instant.now())
+
+        assertThrows<GreetingNotPendingException> {
+            accepted.expire()
+        }
     }
 
     @Test

--- a/services/social/src/test/kotlin/com/mungcle/social/infrastructure/persistence/GreetingRepositoryIntegrationTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/infrastructure/persistence/GreetingRepositoryIntegrationTest.kt
@@ -1,0 +1,168 @@
+package com.mungcle.social.infrastructure.persistence
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Testcontainers + JDBC 기반 social 서비스 integration 테스트.
+ * save, findById, findBySenderAndWalk unique 제약, findByUserId 필터를 실제 PostgreSQL에서 검증한다.
+ */
+@Testcontainers
+class GreetingRepositoryIntegrationTest {
+
+    companion object {
+        private val idSeq = AtomicLong(1000L)
+
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("mungcle_test")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/migration/V1__init_social_schema.sql")
+
+        private lateinit var conn: Connection
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            conn = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+            conn.autoCommit = true
+        }
+    }
+
+    @BeforeEach
+    fun cleanup() {
+        conn.createStatement().execute("DELETE FROM social.greetings")
+    }
+
+    private fun insertGreeting(
+        id: Long = idSeq.getAndIncrement(),
+        senderUserId: Long = 10L,
+        senderDogId: Long = 100L,
+        receiverUserId: Long = 20L,
+        receiverDogId: Long = 200L,
+        receiverWalkId: Long = 300L,
+        status: String = "PENDING",
+        expiresAt: Instant = Instant.now().plusSeconds(300),
+        respondedAt: Instant? = null,
+    ): Long {
+        val ps = conn.prepareStatement(
+            """INSERT INTO social.greetings
+               (id, sender_user_id, sender_dog_id, receiver_user_id, receiver_dog_id, receiver_walk_id,
+                status, created_at, responded_at, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), ?, ?)"""
+        )
+        ps.setLong(1, id)
+        ps.setLong(2, senderUserId)
+        ps.setLong(3, senderDogId)
+        ps.setLong(4, receiverUserId)
+        ps.setLong(5, receiverDogId)
+        ps.setLong(6, receiverWalkId)
+        ps.setString(7, status)
+        ps.setTimestamp(8, respondedAt?.let { Timestamp.from(it) })
+        ps.setTimestamp(9, Timestamp.from(expiresAt))
+        ps.executeUpdate()
+        return id
+    }
+
+    @Test
+    fun `save and findById — 기본 필드 검증`() {
+        val id = insertGreeting(senderUserId = 10L, receiverUserId = 20L, status = "PENDING")
+
+        val ps = conn.prepareStatement("SELECT * FROM social.greetings WHERE id = ?")
+        ps.setLong(1, id)
+        val rs = ps.executeQuery()
+        assertTrue(rs.next())
+        assertEquals(10L, rs.getLong("sender_user_id"))
+        assertEquals(20L, rs.getLong("receiver_user_id"))
+        assertEquals("PENDING", rs.getString("status"))
+    }
+
+    @Test
+    fun `findBySenderAndWalk — 동일 조합 존재하면 반환`() {
+        insertGreeting(senderUserId = 10L, receiverWalkId = 300L)
+
+        val ps = conn.prepareStatement(
+            "SELECT * FROM social.greetings WHERE sender_user_id = ? AND receiver_walk_id = ?"
+        )
+        ps.setLong(1, 10L)
+        ps.setLong(2, 300L)
+        val rs = ps.executeQuery()
+        assertTrue(rs.next())
+    }
+
+    @Test
+    fun `unique 제약 — 동일 senderUserId + receiverWalkId 중복 삽입 실패`() {
+        insertGreeting(id = idSeq.getAndIncrement(), senderUserId = 10L, receiverWalkId = 300L)
+
+        var thrown = false
+        try {
+            insertGreeting(id = idSeq.getAndIncrement(), senderUserId = 10L, receiverWalkId = 300L)
+        } catch (e: Exception) {
+            thrown = true
+        }
+        assertTrue(thrown, "unique 제약 위반이 발생해야 합니다")
+    }
+
+    @Test
+    fun `findByUserId — 발신자 필터`() {
+        insertGreeting(senderUserId = 10L, receiverUserId = 20L, status = "PENDING")
+        insertGreeting(senderUserId = 10L, receiverUserId = 21L, status = "ACCEPTED", receiverWalkId = 301L)
+        insertGreeting(senderUserId = 30L, receiverUserId = 10L, status = "PENDING", receiverWalkId = 302L)
+
+        val ps = conn.prepareStatement(
+            "SELECT * FROM social.greetings WHERE sender_user_id = ?"
+        )
+        ps.setLong(1, 10L)
+        val rs = ps.executeQuery()
+        var count = 0
+        while (rs.next()) count++
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun `findByUserId — 수신자 필터`() {
+        insertGreeting(senderUserId = 10L, receiverUserId = 20L)
+        insertGreeting(senderUserId = 11L, receiverUserId = 20L, receiverWalkId = 301L)
+        insertGreeting(senderUserId = 20L, receiverUserId = 30L, receiverWalkId = 302L)
+
+        val ps = conn.prepareStatement(
+            "SELECT * FROM social.greetings WHERE receiver_user_id = ?"
+        )
+        ps.setLong(1, 20L)
+        val rs = ps.executeQuery()
+        var count = 0
+        while (rs.next()) count++
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun `idx_greetings_receiver 인덱스 존재 확인`() {
+        val rs = conn.createStatement().executeQuery(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = 'social' AND tablename = 'greetings' AND indexname = 'idx_greetings_receiver'"
+        )
+        assertTrue(rs.next(), "idx_greetings_receiver 인덱스가 존재해야 합니다")
+    }
+
+    @Test
+    fun `idx_greetings_sender 인덱스 존재 확인`() {
+        val rs = conn.createStatement().executeQuery(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = 'social' AND tablename = 'greetings' AND indexname = 'idx_greetings_sender'"
+        )
+        assertTrue(rs.next(), "idx_greetings_sender 인덱스가 존재해야 합니다")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,3 +33,4 @@ include("common:grpc-client")
 // Services
 include("services:pet-profile")
 include("services:walks")
+include("services:social")


### PR DESCRIPTION
## Summary
- Social 서비스 신규 생성 (services/social)
- Greeting CRUD 4 RPC 구현 (CreateGreeting, RespondGreeting, GetGreeting, ListGreetings)
- 클린 아키텍처: domain → application → infrastructure 레이어 분리
- Kafka 이벤트 발행 (greeting.created, greeting.accepted)
- IdentityGrpcClient (차단 체크), WalksGrpcClient (stub — task-08에서 완성)
- Flyway 마이그레이션 (social 스키마, TIMESTAMPTZ 사용)
- Unit 테스트 + Testcontainers Integration 테스트

## Task Reference
- plan-docs/tasks/06-social-greetings.md

## Test plan
- [x] `./gradlew :services:social:clean :services:social:test` 통과
- [ ] Greeting 상태 전이 (PENDING→ACCEPTED, PENDING→EXPIRED)
- [ ] 차단 관계 생성 거부
- [ ] 중복 인사 거부
- [ ] unique constraint 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>