### PR TITLE
feat(walks): 시간대 패턴 조회 + CRON 만�� + Kafka 이벤트

### DIFF
--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/command/ExpireWalksCommandHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/command/ExpireWalksCommandHandler.kt
@@ -1,0 +1,26 @@
+package com.mungcle.walks.application.command
+
+import com.mungcle.walks.domain.port.`in`.ExpireWalksUseCase
+import com.mungcle.walks.domain.port.out.WalkEventPublisherPort
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class ExpireWalksCommandHandler(
+    private val walkRepository: WalkRepositoryPort,
+    private val walkEventPublisher: WalkEventPublisherPort,
+) : ExpireWalksUseCase {
+
+    @Transactional
+    override fun execute(now: Instant): Int {
+        val expiredWalks = walkRepository.findExpiredActive(now)
+        expiredWalks.forEach { walk ->
+            val ended = walk.end(now)
+            walkRepository.save(ended)
+            walkEventPublisher.publishWalkExpired(walk.id, walk.userId)
+        }
+        return expiredWalks.size
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/command/ExpireWalksCommandHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/command/ExpireWalksCommandHandler.kt
@@ -16,11 +16,15 @@ class ExpireWalksCommandHandler(
     @Transactional
     override fun execute(now: Instant): Int {
         val expiredWalks = walkRepository.findExpiredActive(now)
-        expiredWalks.forEach { walk ->
-            val ended = walk.end(now)
-            walkRepository.save(ended)
+        if (expiredWalks.isEmpty()) return 0
+
+        val endedWalks = expiredWalks.map { it.end(now) }
+        walkRepository.saveAll(endedWalks)
+
+        endedWalks.forEach { walk ->
             walkEventPublisher.publishWalkExpired(walk.id, walk.userId)
         }
-        return expiredWalks.size
+
+        return endedWalks.size
     }
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/command/StartWalkCommandHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/command/StartWalkCommandHandler.kt
@@ -5,15 +5,18 @@ import com.mungcle.walks.domain.exception.WalkAlreadyActiveException
 import com.mungcle.walks.domain.model.Walk
 import com.mungcle.walks.domain.model.WalkStatus
 import com.mungcle.walks.domain.port.`in`.StartWalkUseCase
+import com.mungcle.walks.domain.port.out.WalkPatternRepositoryPort
 import com.mungcle.walks.domain.port.out.WalkRepositoryPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
 import java.time.Instant
+import java.time.ZoneId
 
 @Service
 class StartWalkCommandHandler(
     private val walkRepository: WalkRepositoryPort,
+    private val walkPatternRepository: WalkPatternRepositoryPort,
 ) : StartWalkUseCase {
 
     @Transactional
@@ -33,6 +36,15 @@ class StartWalkCommandHandler(
             startedAt = now,
             endsAt = now.plus(Duration.ofMinutes(60)),
         )
-        return walkRepository.save(walk)
+        val saved = walkRepository.save(walk)
+
+        walkPatternRepository.upsert(
+            gridCell = saved.gridCell.value,
+            hourOfDay = now.atZone(ZoneId.of("Asia/Seoul")).hour,
+            dogId = saved.dogId,
+            walkedAt = now,
+        )
+
+        return saved
     }
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetNearbyPatternsQueryHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetNearbyPatternsQueryHandler.kt
@@ -28,14 +28,16 @@ class GetNearbyPatternsQueryHandler(
 
         val cutoff = now.minus(14, ChronoUnit.DAYS)
 
-        // identity 서비스에서 차단 목록 직접 조회 + request의 것도 합침 (union)
-        // 패턴은 dogId 기준이므로, 블록된 userId 소유의 dogId를 제외하려면 추가 조회가 필요.
-        // 현재는 차단 목록을 수집만 하며, ACTIVE 산책 중 차단된 userId 소유 dogId는 이미 activeWalkDogIds에서 제외됨.
         val identityBlockedIds = identityPort.getBlockedUserIds(query.userId)
-        @Suppress("UNUSED_VARIABLE")
-        val blockedUserIds = (query.blockedUserIds + identityBlockedIds).toSet()
+        val allBlockedUserIds = (query.blockedUserIds + identityBlockedIds).distinct()
 
-        val activeWalkDogIds = walkRepository
+        val blockedDogIds = if (allBlockedUserIds.isNotEmpty()) {
+            walkRepository.findDogIdsByUserIds(allBlockedUserIds)
+        } else {
+            emptyList()
+        }
+
+        val activeDogIds = walkRepository
             .findActiveOpenByGridCells(GridCell.adjacentCells(centerCell))
             .map { it.dogId }
             .toSet()
@@ -43,7 +45,8 @@ class GetNearbyPatternsQueryHandler(
         return walkPatternRepository
             .findByGridCellsAndHourRange(adjacentCells, hourRange)
             .filter { it.lastWalkedAt.isAfter(cutoff) }
-            .filter { it.dogId !in activeWalkDogIds }
+            .filter { it.dogId !in activeDogIds }
+            .filter { it.dogId !in blockedDogIds }
             .sortedByDescending { it.walkCount }
             .take(10)
     }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetNearbyPatternsQueryHandler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/application/query/GetNearbyPatternsQueryHandler.kt
@@ -1,0 +1,50 @@
+package com.mungcle.walks.application.query
+
+import com.mungcle.common.domain.GridCell
+import com.mungcle.walks.domain.model.WalkPattern
+import com.mungcle.walks.domain.port.`in`.GetNearbyPatternsUseCase
+import com.mungcle.walks.domain.port.out.IdentityPort
+import com.mungcle.walks.domain.port.out.WalkPatternRepositoryPort
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+@Service
+class GetNearbyPatternsQueryHandler(
+    private val walkPatternRepository: WalkPatternRepositoryPort,
+    private val walkRepository: WalkRepositoryPort,
+    private val identityPort: IdentityPort,
+) : GetNearbyPatternsUseCase {
+
+    override suspend fun execute(query: GetNearbyPatternsUseCase.Query): List<WalkPattern> {
+        val centerCell = GridCell(query.gridCell)
+        val adjacentCells = GridCell.adjacentCells(centerCell).map { it.value }
+
+        val now = Instant.now()
+        val currentHour = now.atZone(ZoneId.of("Asia/Seoul")).hour
+        val hourRange = ((currentHour - 1).coerceAtLeast(0))..((currentHour + 1).coerceAtMost(23))
+
+        val cutoff = now.minus(14, ChronoUnit.DAYS)
+
+        // identity 서비스에서 차단 목록 직접 조회 + request의 것도 합침 (union)
+        // 패턴은 dogId 기준이므로, 블록된 userId 소유의 dogId를 제외하려면 추가 조회가 필요.
+        // 현재는 차단 목록을 수집만 하며, ACTIVE 산책 중 차단된 userId 소유 dogId는 이미 activeWalkDogIds에서 제외됨.
+        val identityBlockedIds = identityPort.getBlockedUserIds(query.userId)
+        @Suppress("UNUSED_VARIABLE")
+        val blockedUserIds = (query.blockedUserIds + identityBlockedIds).toSet()
+
+        val activeWalkDogIds = walkRepository
+            .findActiveOpenByGridCells(GridCell.adjacentCells(centerCell))
+            .map { it.dogId }
+            .toSet()
+
+        return walkPatternRepository
+            .findByGridCellsAndHourRange(adjacentCells, hourRange)
+            .filter { it.lastWalkedAt.isAfter(cutoff) }
+            .filter { it.dogId !in activeWalkDogIds }
+            .sortedByDescending { it.walkCount }
+            .take(10)
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/config/WalksConfig.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/config/WalksConfig.kt
@@ -1,13 +1,25 @@
 package com.mungcle.walks.config
 
+import com.mungcle.walks.domain.port.out.WalkEventPublisherPort
+import com.mungcle.walks.domain.port.out.WalkPatternRepositoryPort
 import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import com.mungcle.walks.infrastructure.kafka.WalkExpiredEventPublisher
+import com.mungcle.walks.infrastructure.persistence.WalkPatternRepositoryAdapter
 import com.mungcle.walks.infrastructure.persistence.WalkRepositoryAdapter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
+@EnableScheduling
 class WalksConfig {
 
     @Bean
     fun walkRepositoryPort(adapter: WalkRepositoryAdapter): WalkRepositoryPort = adapter
+
+    @Bean
+    fun walkPatternRepositoryPort(adapter: WalkPatternRepositoryAdapter): WalkPatternRepositoryPort = adapter
+
+    @Bean
+    fun walkEventPublisherPort(publisher: WalkExpiredEventPublisher): WalkEventPublisherPort = publisher
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/WalkPattern.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/model/WalkPattern.kt
@@ -1,0 +1,16 @@
+package com.mungcle.walks.domain.model
+
+import java.time.Instant
+
+/**
+ * 시간대 산책 패턴 도메인 모델.
+ * 특정 그리드 셀에서 특정 시간대에 반려견이 얼마나 자주 산책하는지 집계한 데이터.
+ */
+data class WalkPattern(
+    val id: Long = 0,
+    val gridCell: String,
+    val hourOfDay: Int,  // 0~23
+    val dogId: Long,
+    val walkCount: Int,
+    val lastWalkedAt: Instant,
+)

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/ExpireWalksUseCase.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/ExpireWalksUseCase.kt
@@ -1,0 +1,15 @@
+package com.mungcle.walks.domain.port.`in`
+
+import java.time.Instant
+
+/**
+ * 만료된 산책을 일괄 종료하는 유즈케이스.
+ */
+interface ExpireWalksUseCase {
+    /**
+     * endsAt이 now 이전인 ACTIVE 산책을 모두 종료 처리한다.
+     * @param now 기준 시각
+     * @return 만료 처리된 산책 수
+     */
+    fun execute(now: Instant): Int
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/GetNearbyPatternsUseCase.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/in/GetNearbyPatternsUseCase.kt
@@ -1,0 +1,21 @@
+package com.mungcle.walks.domain.port.`in`
+
+import com.mungcle.walks.domain.model.WalkPattern
+
+/**
+ * 인근 그리드 셀의 시간대별 산책 패턴 조회 유즈케이스.
+ */
+interface GetNearbyPatternsUseCase {
+    /**
+     * 인근 셀의 패턴 목록을 반환한다.
+     * @param query 조회 조건 (gridCell, userId, blockedUserIds)
+     * @return walkCount 기준 상위 10개의 WalkPattern 목록
+     */
+    suspend fun execute(query: Query): List<WalkPattern>
+
+    data class Query(
+        val gridCell: String,
+        val userId: Long,
+        val blockedUserIds: List<Long>,
+    )
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkEventPublisherPort.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkEventPublisherPort.kt
@@ -1,0 +1,13 @@
+package com.mungcle.walks.domain.port.out
+
+/**
+ * 산책 관련 Kafka 이벤트 발행 포트.
+ */
+interface WalkEventPublisherPort {
+    /**
+     * 산책 만료 이벤트를 발행한다.
+     * @param walkId 만료된 산책 ID
+     * @param userId 산책 소유 사용자 ID
+     */
+    fun publishWalkExpired(walkId: Long, userId: Long)
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkPatternRepositoryPort.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkPatternRepositoryPort.kt
@@ -1,0 +1,27 @@
+package com.mungcle.walks.domain.port.out
+
+import com.mungcle.walks.domain.model.WalkPattern
+import java.time.Instant
+
+/**
+ * 산책 패턴 저장소 포트.
+ */
+interface WalkPatternRepositoryPort {
+    /**
+     * 지정된 그리드 셀과 시간 범위에 해당하는 패턴 목록을 반환한다.
+     * @param gridCells 조회 대상 그리드 셀 목록
+     * @param hourRange 조회 대상 시간 범위 (0~23)
+     * @return 해당 조건의 WalkPattern 목록
+     */
+    fun findByGridCellsAndHourRange(gridCells: List<String>, hourRange: IntRange): List<WalkPattern>
+
+    /**
+     * 특정 그리드 셀, 시간대, 반려견의 패턴을 upsert한다.
+     * 이미 존재하면 walk_count를 증가하고 last_walked_at을 갱신한다.
+     * @param gridCell 그리드 셀 ID
+     * @param hourOfDay 산책 시각 (0~23)
+     * @param dogId 반려견 ID
+     * @param walkedAt 산책 시각 (Instant)
+     */
+    fun upsert(gridCell: String, hourOfDay: Int, dogId: Long, walkedAt: Instant)
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkRepositoryPort.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkRepositoryPort.kt
@@ -2,6 +2,7 @@ package com.mungcle.walks.domain.port.out
 
 import com.mungcle.common.domain.GridCell
 import com.mungcle.walks.domain.model.Walk
+import java.time.Instant
 
 interface WalkRepositoryPort {
     fun save(walk: Walk): Walk
@@ -9,4 +10,10 @@ interface WalkRepositoryPort {
     fun findActiveByDogId(dogId: Long): Walk?
     fun findActiveByUserId(userId: Long): List<Walk>
     fun findActiveOpenByGridCells(gridCells: List<GridCell>): List<Walk>
+
+    /**
+     * endsAt이 now 이전인 ACTIVE 상태의 산책 목록을 반환한다.
+     * @param now 기준 시각
+     */
+    fun findExpiredActive(now: Instant): List<Walk>
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkRepositoryPort.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/domain/port/out/WalkRepositoryPort.kt
@@ -16,4 +16,8 @@ interface WalkRepositoryPort {
      * @param now 기준 시각
      */
     fun findExpiredActive(now: Instant): List<Walk>
+
+    fun findDogIdsByUserIds(userIds: List<Long>): List<Long>
+
+    fun saveAll(walks: List<Walk>): List<Walk>
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/server/WalksGrpcService.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/server/WalksGrpcService.kt
@@ -3,6 +3,7 @@ package com.mungcle.walks.infrastructure.grpc.server
 import com.mungcle.walks.domain.exception.WalkException
 import com.mungcle.walks.domain.model.WalkType
 import com.mungcle.walks.domain.port.`in`.GetMyActiveWalksUseCase
+import com.mungcle.walks.domain.port.`in`.GetNearbyPatternsUseCase
 import com.mungcle.walks.domain.port.`in`.GetNearbyWalksUseCase
 import com.mungcle.walks.domain.port.`in`.GetWalkGridCellUseCase
 import com.mungcle.walks.domain.port.`in`.StartWalkUseCase
@@ -20,10 +21,12 @@ import com.mungcle.proto.walks.v1.StopWalkRequest
 import com.mungcle.proto.walks.v1.WalkInfo
 import com.mungcle.proto.walks.v1.WalksServiceGrpcKt
 import com.mungcle.proto.walks.v1.getMyActiveWalksResponse
+import com.mungcle.proto.walks.v1.getNearbyPatternsResponse
 import com.mungcle.proto.walks.v1.getNearbyWalksResponse
 import com.mungcle.proto.walks.v1.getWalkGridCellResponse
 import com.mungcle.proto.walks.v1.nearbyWalkInfo
 import com.mungcle.proto.walks.v1.walkInfo
+import com.mungcle.proto.walks.v1.walkPatternInfo
 import com.mungcle.walks.domain.model.Walk
 import io.grpc.Status
 import io.grpc.StatusException
@@ -36,6 +39,7 @@ class WalksGrpcService(
     private val getNearbyWalksUseCase: GetNearbyWalksUseCase,
     private val getMyActiveWalksUseCase: GetMyActiveWalksUseCase,
     private val getWalkGridCellUseCase: GetWalkGridCellUseCase,
+    private val getNearbyPatternsUseCase: GetNearbyPatternsUseCase,
 ) : WalksServiceGrpcKt.WalksServiceCoroutineImplBase() {
 
     override suspend fun startWalk(request: StartWalkRequest): WalkInfo {
@@ -120,9 +124,26 @@ class WalksGrpcService(
     }
 
     override suspend fun getNearbyPatterns(request: GetNearbyPatternsRequest): GetNearbyPatternsResponse {
-        throw StatusException(
-            Status.UNIMPLEMENTED.withDescription("Task 05에서 구현 예정")
-        )
+        try {
+            val results = getNearbyPatternsUseCase.execute(
+                GetNearbyPatternsUseCase.Query(
+                    gridCell = request.gridCell,
+                    userId = request.userId,
+                    blockedUserIds = request.blockedUserIdsList,
+                )
+            )
+            return getNearbyPatternsResponse {
+                patterns += results.map { pattern ->
+                    walkPatternInfo {
+                        dogId = pattern.dogId
+                        typicalHour = pattern.hourOfDay
+                        countLast14Days = pattern.walkCount
+                    }
+                }
+            }
+        } catch (e: WalkException) {
+            throw e.toStatusException()
+        }
     }
 
     private fun Walk.toWalkInfo(): WalkInfo = walkInfo {

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/kafka/WalkExpiredEventPublisher.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/kafka/WalkExpiredEventPublisher.kt
@@ -1,0 +1,19 @@
+package com.mungcle.walks.infrastructure.kafka
+
+import com.mungcle.common.kafka.Topics
+import com.mungcle.common.kafka.WalkExpiredEvent
+import com.mungcle.walks.domain.port.out.WalkEventPublisherPort
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class WalkExpiredEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, WalkExpiredEvent>,
+) : WalkEventPublisherPort {
+
+    override fun publishWalkExpired(walkId: Long, userId: Long) {
+        val event = WalkExpiredEvent(walkId = walkId, userId = userId, occurredAt = Instant.now())
+        kafkaTemplate.send(Topics.WALK_EXPIRED, walkId.toString(), event)
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternEntity.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternEntity.kt
@@ -1,0 +1,31 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "walk_patterns", schema = "walks")
+open class WalkPatternEntity(
+    @Id
+    @Tsid
+    open var id: Long = 0,
+
+    @Column(name = "grid_cell", nullable = false)
+    open var gridCell: String = "",
+
+    @Column(name = "hour_of_day", nullable = false)
+    open var hourOfDay: Int = 0,
+
+    @Column(name = "dog_id", nullable = false)
+    open var dogId: Long = 0,
+
+    @Column(name = "walk_count", nullable = false)
+    open var walkCount: Int = 1,
+
+    @Column(name = "last_walked_at", nullable = false)
+    open var lastWalkedAt: Instant = Instant.now(),
+)

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternMapper.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternMapper.kt
@@ -1,0 +1,15 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import com.mungcle.walks.domain.model.WalkPattern
+
+object WalkPatternMapper {
+
+    fun toDomain(entity: WalkPatternEntity): WalkPattern = WalkPattern(
+        id = entity.id,
+        gridCell = entity.gridCell,
+        hourOfDay = entity.hourOfDay,
+        dogId = entity.dogId,
+        walkCount = entity.walkCount,
+        lastWalkedAt = entity.lastWalkedAt,
+    )
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternRepositoryAdapter.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternRepositoryAdapter.kt
@@ -1,0 +1,23 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import com.mungcle.walks.domain.model.WalkPattern
+import com.mungcle.walks.domain.port.out.WalkPatternRepositoryPort
+import org.springframework.stereotype.Repository
+import java.time.Instant
+import java.util.concurrent.ThreadLocalRandom
+
+@Repository
+class WalkPatternRepositoryAdapter(
+    private val springDataRepository: WalkPatternSpringDataRepository,
+) : WalkPatternRepositoryPort {
+
+    override fun findByGridCellsAndHourRange(gridCells: List<String>, hourRange: IntRange): List<WalkPattern> =
+        springDataRepository.findByGridCellsAndHourRange(gridCells, hourRange.first, hourRange.last)
+            .map(WalkPatternMapper::toDomain)
+
+    override fun upsert(gridCell: String, hourOfDay: Int, dogId: Long, walkedAt: Instant) {
+        // ON CONFLICT handles duplicate (grid_cell, hour_of_day, dog_id) — ID is only used for new inserts
+        val id = (Instant.now().toEpochMilli() shl 22) or (ThreadLocalRandom.current().nextLong(0L, 1L shl 22))
+        springDataRepository.upsert(id, gridCell, hourOfDay, dogId, walkedAt)
+    }
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternRepositoryAdapter.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternRepositoryAdapter.kt
@@ -2,9 +2,9 @@ package com.mungcle.walks.infrastructure.persistence
 
 import com.mungcle.walks.domain.model.WalkPattern
 import com.mungcle.walks.domain.port.out.WalkPatternRepositoryPort
+import io.hypersistence.tsid.TSID
 import org.springframework.stereotype.Repository
 import java.time.Instant
-import java.util.concurrent.ThreadLocalRandom
 
 @Repository
 class WalkPatternRepositoryAdapter(
@@ -17,7 +17,7 @@ class WalkPatternRepositoryAdapter(
 
     override fun upsert(gridCell: String, hourOfDay: Int, dogId: Long, walkedAt: Instant) {
         // ON CONFLICT handles duplicate (grid_cell, hour_of_day, dog_id) — ID is only used for new inserts
-        val id = (Instant.now().toEpochMilli() shl 22) or (ThreadLocalRandom.current().nextLong(0L, 1L shl 22))
+        val id = TSID.Factory.getTsid().toLong()
         springDataRepository.upsert(id, gridCell, hourOfDay, dogId, walkedAt)
     }
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternSpringDataRepository.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternSpringDataRepository.kt
@@ -1,0 +1,38 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.Instant
+
+interface WalkPatternSpringDataRepository : JpaRepository<WalkPatternEntity, Long> {
+
+    @Query(
+        "SELECT p FROM WalkPatternEntity p WHERE p.gridCell IN :gridCells AND p.hourOfDay BETWEEN :minHour AND :maxHour"
+    )
+    fun findByGridCellsAndHourRange(
+        @Param("gridCells") gridCells: List<String>,
+        @Param("minHour") minHour: Int,
+        @Param("maxHour") maxHour: Int,
+    ): List<WalkPatternEntity>
+
+    @Modifying
+    @Query(
+        value = """
+            INSERT INTO walks.walk_patterns (id, grid_cell, hour_of_day, dog_id, walk_count, last_walked_at)
+            VALUES (:id, :gridCell, :hourOfDay, :dogId, 1, :walkedAt)
+            ON CONFLICT (grid_cell, hour_of_day, dog_id)
+            DO UPDATE SET walk_count = walks.walk_patterns.walk_count + 1,
+                          last_walked_at = EXCLUDED.last_walked_at
+        """,
+        nativeQuery = true,
+    )
+    fun upsert(
+        @Param("id") id: Long,
+        @Param("gridCell") gridCell: String,
+        @Param("hourOfDay") hourOfDay: Int,
+        @Param("dogId") dogId: Long,
+        @Param("walkedAt") walkedAt: Instant,
+    )
+}

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkRepositoryAdapter.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkRepositoryAdapter.kt
@@ -32,4 +32,12 @@ class WalkRepositoryAdapter(
 
     override fun findExpiredActive(now: Instant): List<Walk> =
         springDataRepository.findByStatusAndEndsAtBefore(now).map(WalkMapper::toDomain)
+
+    override fun findDogIdsByUserIds(userIds: List<Long>): List<Long> =
+        springDataRepository.findDogIdsByUserIds(userIds)
+
+    override fun saveAll(walks: List<Walk>): List<Walk> {
+        val entities = walks.map { WalkMapper.toEntity(it) }
+        return springDataRepository.saveAll(entities).map { WalkMapper.toDomain(it) }
+    }
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkRepositoryAdapter.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkRepositoryAdapter.kt
@@ -4,6 +4,7 @@ import com.mungcle.common.domain.GridCell
 import com.mungcle.walks.domain.model.Walk
 import com.mungcle.walks.domain.port.out.WalkRepositoryPort
 import org.springframework.stereotype.Repository
+import java.time.Instant
 
 @Repository
 class WalkRepositoryAdapter(
@@ -28,4 +29,7 @@ class WalkRepositoryAdapter(
     override fun findActiveOpenByGridCells(gridCells: List<GridCell>): List<Walk> =
         springDataRepository.findActiveOpenByGridCells(gridCells.map { it.value })
             .map(WalkMapper::toDomain)
+
+    override fun findExpiredActive(now: Instant): List<Walk> =
+        springDataRepository.findByStatusAndEndsAtBefore(now).map(WalkMapper::toDomain)
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkSpringDataRepository.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkSpringDataRepository.kt
@@ -3,6 +3,7 @@ package com.mungcle.walks.infrastructure.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.Instant
 import java.util.Optional
 
 interface WalkSpringDataRepository : JpaRepository<WalkEntity, Long> {
@@ -15,4 +16,7 @@ interface WalkSpringDataRepository : JpaRepository<WalkEntity, Long> {
 
     @Query("SELECT w FROM WalkEntity w WHERE w.gridCell IN :gridCells AND w.status = 'ACTIVE' AND w.type = 'OPEN'")
     fun findActiveOpenByGridCells(@Param("gridCells") gridCells: List<String>): List<WalkEntity>
+
+    @Query("SELECT w FROM WalkEntity w WHERE w.status = 'ACTIVE' AND w.endsAt < :now")
+    fun findByStatusAndEndsAtBefore(@Param("now") now: Instant): List<WalkEntity>
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkSpringDataRepository.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/persistence/WalkSpringDataRepository.kt
@@ -19,4 +19,7 @@ interface WalkSpringDataRepository : JpaRepository<WalkEntity, Long> {
 
     @Query("SELECT w FROM WalkEntity w WHERE w.status = 'ACTIVE' AND w.endsAt < :now")
     fun findByStatusAndEndsAtBefore(@Param("now") now: Instant): List<WalkEntity>
+
+    @Query("SELECT DISTINCT w.dogId FROM WalkEntity w WHERE w.userId IN :userIds")
+    fun findDogIdsByUserIds(@Param("userIds") userIds: List<Long>): List<Long>
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/scheduler/WalkExpiryScheduler.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/scheduler/WalkExpiryScheduler.kt
@@ -1,0 +1,17 @@
+package com.mungcle.walks.infrastructure.scheduler
+
+import com.mungcle.walks.domain.port.`in`.ExpireWalksUseCase
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class WalkExpiryScheduler(
+    private val expireWalks: ExpireWalksUseCase,
+) {
+
+    @Scheduled(fixedRate = 60_000)
+    fun expireWalks() {
+        expireWalks.execute(Instant.now())
+    }
+}

--- a/services/walks/src/main/resources/db/migration/V2__add_walk_patterns.sql
+++ b/services/walks/src/main/resources/db/migration/V2__add_walk_patterns.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS walks.walk_patterns (
+    id          BIGINT PRIMARY KEY,
+    grid_cell   VARCHAR(20) NOT NULL,
+    hour_of_day INTEGER NOT NULL CHECK (hour_of_day BETWEEN 0 AND 23),
+    dog_id      BIGINT NOT NULL,
+    walk_count  INTEGER NOT NULL DEFAULT 1,
+    last_walked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (grid_cell, hour_of_day, dog_id)
+);
+CREATE INDEX idx_walk_patterns_grid_hour ON walks.walk_patterns (grid_cell, hour_of_day);

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/command/ExpireWalksCommandHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/command/ExpireWalksCommandHandlerTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ExpireWalksCommandHandlerTest {
 
@@ -35,17 +36,18 @@ class ExpireWalksCommandHandlerTest {
     )
 
     @Test
-    fun `만료 대상 산책을 찾아 end 처리 후 저장`() {
+    fun `만료 대상 산책을 찾아 end 처리 후 saveAll로 배치 저장`() {
         val walk = createWalk(id = 1L)
         every { walkRepository.findExpiredActive(now) } returns listOf(walk)
-        val savedSlot = slot<Walk>()
-        every { walkRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+        val savedSlot = slot<List<Walk>>()
+        every { walkRepository.saveAll(capture(savedSlot)) } answers { savedSlot.captured }
 
         handler.execute(now)
 
         val saved = savedSlot.captured
-        assertEquals(WalkStatus.ENDED, saved.status)
-        assertEquals(now, saved.endsAt)
+        assertEquals(1, saved.size)
+        assertEquals(WalkStatus.ENDED, saved[0].status)
+        assertEquals(now, saved[0].endsAt)
     }
 
     @Test
@@ -53,7 +55,7 @@ class ExpireWalksCommandHandlerTest {
         val walk1 = createWalk(id = 1L, userId = 100L)
         val walk2 = createWalk(id = 2L, userId = 200L)
         every { walkRepository.findExpiredActive(now) } returns listOf(walk1, walk2)
-        every { walkRepository.save(any()) } answers { firstArg() }
+        every { walkRepository.saveAll(any()) } answers { firstArg() }
 
         handler.execute(now)
 
@@ -65,7 +67,7 @@ class ExpireWalksCommandHandlerTest {
     fun `만료된 산책 수 반환`() {
         val walks = listOf(createWalk(id = 1L), createWalk(id = 2L), createWalk(id = 3L))
         every { walkRepository.findExpiredActive(now) } returns walks
-        every { walkRepository.save(any()) } answers { firstArg() }
+        every { walkRepository.saveAll(any()) } answers { firstArg() }
 
         val count = handler.execute(now)
 
@@ -80,5 +82,18 @@ class ExpireWalksCommandHandlerTest {
 
         assertEquals(0, count)
         verify(exactly = 0) { walkEventPublisher.publishWalkExpired(any(), any()) }
+        verify(exactly = 0) { walkRepository.saveAll(any()) }
+    }
+
+    @Test
+    fun `saveAll이 개별 save 대신 단일 배치 호출로 실행`() {
+        val walks = listOf(createWalk(id = 1L), createWalk(id = 2L))
+        every { walkRepository.findExpiredActive(now) } returns walks
+        every { walkRepository.saveAll(any()) } answers { firstArg() }
+
+        handler.execute(now)
+
+        verify(exactly = 1) { walkRepository.saveAll(any()) }
+        verify(exactly = 0) { walkRepository.save(any()) }
     }
 }

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/command/ExpireWalksCommandHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/command/ExpireWalksCommandHandlerTest.kt
@@ -1,0 +1,84 @@
+package com.mungcle.walks.application.command
+
+import com.mungcle.common.domain.GridCell
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkStatus
+import com.mungcle.walks.domain.model.WalkType
+import com.mungcle.walks.domain.port.out.WalkEventPublisherPort
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class ExpireWalksCommandHandlerTest {
+
+    private val walkRepository: WalkRepositoryPort = mockk()
+    private val walkEventPublisher: WalkEventPublisherPort = mockk(relaxed = true)
+    private val handler = ExpireWalksCommandHandler(walkRepository, walkEventPublisher)
+
+    private val now = Instant.now()
+
+    private fun createWalk(id: Long, userId: Long = 1L, endsAt: Instant = now.minus(Duration.ofMinutes(1))) = Walk(
+        id = id,
+        dogId = id * 10,
+        userId = userId,
+        type = WalkType.OPEN,
+        gridCell = GridCell("10:20"),
+        status = WalkStatus.ACTIVE,
+        startedAt = now.minus(Duration.ofMinutes(70)),
+        endsAt = endsAt,
+    )
+
+    @Test
+    fun `만료 대상 산책을 찾아 end 처리 후 저장`() {
+        val walk = createWalk(id = 1L)
+        every { walkRepository.findExpiredActive(now) } returns listOf(walk)
+        val savedSlot = slot<Walk>()
+        every { walkRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+        handler.execute(now)
+
+        val saved = savedSlot.captured
+        assertEquals(WalkStatus.ENDED, saved.status)
+        assertEquals(now, saved.endsAt)
+    }
+
+    @Test
+    fun `만료된 각 산책에 대해 WalkExpiredEvent 발행`() {
+        val walk1 = createWalk(id = 1L, userId = 100L)
+        val walk2 = createWalk(id = 2L, userId = 200L)
+        every { walkRepository.findExpiredActive(now) } returns listOf(walk1, walk2)
+        every { walkRepository.save(any()) } answers { firstArg() }
+
+        handler.execute(now)
+
+        verify(exactly = 1) { walkEventPublisher.publishWalkExpired(1L, 100L) }
+        verify(exactly = 1) { walkEventPublisher.publishWalkExpired(2L, 200L) }
+    }
+
+    @Test
+    fun `만료된 산책 수 반환`() {
+        val walks = listOf(createWalk(id = 1L), createWalk(id = 2L), createWalk(id = 3L))
+        every { walkRepository.findExpiredActive(now) } returns walks
+        every { walkRepository.save(any()) } answers { firstArg() }
+
+        val count = handler.execute(now)
+
+        assertEquals(3, count)
+    }
+
+    @Test
+    fun `만료 대상이 없으면 0 반환`() {
+        every { walkRepository.findExpiredActive(now) } returns emptyList()
+
+        val count = handler.execute(now)
+
+        assertEquals(0, count)
+        verify(exactly = 0) { walkEventPublisher.publishWalkExpired(any(), any()) }
+    }
+}

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/command/StartWalkCommandHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/command/StartWalkCommandHandlerTest.kt
@@ -6,6 +6,7 @@ import com.mungcle.walks.domain.model.Walk
 import com.mungcle.walks.domain.model.WalkStatus
 import com.mungcle.walks.domain.model.WalkType
 import com.mungcle.walks.domain.port.`in`.StartWalkUseCase
+import com.mungcle.walks.domain.port.out.WalkPatternRepositoryPort
 import com.mungcle.walks.domain.port.out.WalkRepositoryPort
 import io.mockk.every
 import io.mockk.mockk
@@ -20,7 +21,8 @@ import kotlin.test.assertEquals
 class StartWalkCommandHandlerTest {
 
     private val walkRepository: WalkRepositoryPort = mockk()
-    private val handler = StartWalkCommandHandler(walkRepository)
+    private val walkPatternRepository: WalkPatternRepositoryPort = mockk(relaxed = true)
+    private val handler = StartWalkCommandHandler(walkRepository, walkPatternRepository)
 
     private val command = StartWalkUseCase.Command(
         userId = 1L,

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/query/GetNearbyPatternsQueryHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/query/GetNearbyPatternsQueryHandlerTest.kt
@@ -1,0 +1,153 @@
+package com.mungcle.walks.application.query
+
+import com.mungcle.common.domain.GridCell
+import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkPattern
+import com.mungcle.walks.domain.model.WalkStatus
+import com.mungcle.walks.domain.model.WalkType
+import com.mungcle.walks.domain.port.`in`.GetNearbyPatternsUseCase
+import com.mungcle.walks.domain.port.out.IdentityPort
+import com.mungcle.walks.domain.port.out.WalkPatternRepositoryPort
+import com.mungcle.walks.domain.port.out.WalkRepositoryPort
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetNearbyPatternsQueryHandlerTest {
+
+    private val walkPatternRepository: WalkPatternRepositoryPort = mockk()
+    private val walkRepository: WalkRepositoryPort = mockk()
+    private val identityPort: IdentityPort = mockk()
+    private val handler = GetNearbyPatternsQueryHandler(walkPatternRepository, walkRepository, identityPort)
+
+    private val now = Instant.now()
+
+    private fun createPattern(
+        id: Long,
+        dogId: Long,
+        walkCount: Int = 5,
+        lastWalkedAt: Instant = now.minus(1, ChronoUnit.DAYS),
+        gridCell: String = "10:20",
+        hourOfDay: Int = 10,
+    ) = WalkPattern(
+        id = id,
+        dogId = dogId,
+        walkCount = walkCount,
+        lastWalkedAt = lastWalkedAt,
+        gridCell = gridCell,
+        hourOfDay = hourOfDay,
+    )
+
+    private fun createWalk(dogId: Long) = Walk(
+        id = dogId,
+        dogId = dogId,
+        userId = dogId * 10,
+        type = WalkType.OPEN,
+        gridCell = GridCell("10:20"),
+        status = WalkStatus.ACTIVE,
+        startedAt = now,
+        endsAt = now.plus(Duration.ofMinutes(60)),
+    )
+
+    @Test
+    fun `±1시간 범위 내 패턴만 반환`() = runTest {
+        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(
+            createPattern(id = 1L, dogId = 10L),
+        )
+        every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
+
+        val result = handler.execute(
+            GetNearbyPatternsUseCase.Query(gridCell = "10:20", userId = 1L, blockedUserIds = emptyList())
+        )
+
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `14일 초과된 패턴은 제외`() = runTest {
+        val oldPattern = createPattern(id = 1L, dogId = 10L, lastWalkedAt = now.minus(15, ChronoUnit.DAYS))
+        val recentPattern = createPattern(id = 2L, dogId = 20L, lastWalkedAt = now.minus(13, ChronoUnit.DAYS))
+        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(oldPattern, recentPattern)
+        every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
+
+        val result = handler.execute(
+            GetNearbyPatternsUseCase.Query(gridCell = "10:20", userId = 1L, blockedUserIds = emptyList())
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(20L, result[0].dogId)
+    }
+
+    @Test
+    fun `현재 ACTIVE 산책 중인 dogId는 제외`() = runTest {
+        val pattern1 = createPattern(id = 1L, dogId = 10L)
+        val pattern2 = createPattern(id = 2L, dogId = 20L)
+        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(pattern1, pattern2)
+        every { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(createWalk(dogId = 10L))
+        coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
+
+        val result = handler.execute(
+            GetNearbyPatternsUseCase.Query(gridCell = "10:20", userId = 1L, blockedUserIds = emptyList())
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(20L, result[0].dogId)
+    }
+
+    @Test
+    fun `walkCount 기준 top 10만 반환`() = runTest {
+        val patterns = (1..15).map { i ->
+            createPattern(id = i.toLong(), dogId = (i * 10).toLong(), walkCount = i)
+        }
+        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns patterns
+        every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
+
+        val result = handler.execute(
+            GetNearbyPatternsUseCase.Query(gridCell = "10:20", userId = 1L, blockedUserIds = emptyList())
+        )
+
+        assertEquals(10, result.size)
+        // 내림차순 정렬 — walkCount 가장 높은 것부터
+        assertEquals(15, result[0].walkCount)
+        assertEquals(6, result[9].walkCount)
+    }
+
+    @Test
+    fun `blockedUserIds 및 IdentityPort 차단 목록 합산하여 제외`() = runTest {
+        // 이 테스트는 dogId 기준이므로 블록은 userId 기준으로 동작하지 않음
+        // 패턴 자체가 dogId 기반이므로, 실제 차단 처리는 없다는 점을 검증
+        val pattern = createPattern(id = 1L, dogId = 10L)
+        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(pattern)
+        every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        coEvery { identityPort.getBlockedUserIds(1L) } returns emptyList()
+
+        val result = handler.execute(
+            GetNearbyPatternsUseCase.Query(gridCell = "10:20", userId = 1L, blockedUserIds = emptyList())
+        )
+
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `결과가 없으면 빈 리스트 반환`() = runTest {
+        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns emptyList()
+        every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
+
+        val result = handler.execute(
+            GetNearbyPatternsUseCase.Query(gridCell = "10:20", userId = 1L, blockedUserIds = emptyList())
+        )
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/services/walks/src/test/kotlin/com/mungcle/walks/application/query/GetNearbyPatternsQueryHandlerTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/application/query/GetNearbyPatternsQueryHandlerTest.kt
@@ -45,10 +45,10 @@ class GetNearbyPatternsQueryHandlerTest {
         hourOfDay = hourOfDay,
     )
 
-    private fun createWalk(dogId: Long) = Walk(
+    private fun createWalk(dogId: Long, userId: Long = dogId * 10) = Walk(
         id = dogId,
         dogId = dogId,
-        userId = dogId * 10,
+        userId = userId,
         type = WalkType.OPEN,
         gridCell = GridCell("10:20"),
         status = WalkStatus.ACTIVE,
@@ -62,6 +62,7 @@ class GetNearbyPatternsQueryHandlerTest {
             createPattern(id = 1L, dogId = 10L),
         )
         every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        every { walkRepository.findDogIdsByUserIds(any()) } returns emptyList()
         coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
 
         val result = handler.execute(
@@ -77,6 +78,7 @@ class GetNearbyPatternsQueryHandlerTest {
         val recentPattern = createPattern(id = 2L, dogId = 20L, lastWalkedAt = now.minus(13, ChronoUnit.DAYS))
         every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(oldPattern, recentPattern)
         every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        every { walkRepository.findDogIdsByUserIds(any()) } returns emptyList()
         coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
 
         val result = handler.execute(
@@ -93,6 +95,7 @@ class GetNearbyPatternsQueryHandlerTest {
         val pattern2 = createPattern(id = 2L, dogId = 20L)
         every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(pattern1, pattern2)
         every { walkRepository.findActiveOpenByGridCells(any()) } returns listOf(createWalk(dogId = 10L))
+        every { walkRepository.findDogIdsByUserIds(any()) } returns emptyList()
         coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
 
         val result = handler.execute(
@@ -110,6 +113,7 @@ class GetNearbyPatternsQueryHandlerTest {
         }
         every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns patterns
         every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        every { walkRepository.findDogIdsByUserIds(any()) } returns emptyList()
         coEvery { identityPort.getBlockedUserIds(any()) } returns emptyList()
 
         val result = handler.execute(
@@ -123,19 +127,39 @@ class GetNearbyPatternsQueryHandlerTest {
     }
 
     @Test
-    fun `blockedUserIds 및 IdentityPort 차단 목록 합산하여 제외`() = runTest {
-        // 이 테스트는 dogId 기준이므로 블록은 userId 기준으로 동작하지 않음
-        // 패턴 자체가 dogId 기반이므로, 실제 차단 처리는 없다는 점을 검증
-        val pattern = createPattern(id = 1L, dogId = 10L)
-        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(pattern)
+    fun `차단된 userId 소유 dogId는 패턴 결과에서 제외`() = runTest {
+        val pattern1 = createPattern(id = 1L, dogId = 10L) // blockedUser(userId=50) 소유
+        val pattern2 = createPattern(id = 2L, dogId = 20L) // 차단되지 않은 사용자
+        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(pattern1, pattern2)
         every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        // blockedUserIds=[50] → dogId=[10] 매핑
+        every { walkRepository.findDogIdsByUserIds(listOf(50L)) } returns listOf(10L)
         coEvery { identityPort.getBlockedUserIds(1L) } returns emptyList()
+
+        val result = handler.execute(
+            GetNearbyPatternsUseCase.Query(gridCell = "10:20", userId = 1L, blockedUserIds = listOf(50L))
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(20L, result[0].dogId)
+    }
+
+    @Test
+    fun `IdentityPort 차단 목록의 userId 소유 dogId도 제외`() = runTest {
+        val pattern1 = createPattern(id = 1L, dogId = 10L) // identityBlocked(userId=99) 소유
+        val pattern2 = createPattern(id = 2L, dogId = 20L)
+        every { walkPatternRepository.findByGridCellsAndHourRange(any(), any()) } returns listOf(pattern1, pattern2)
+        every { walkRepository.findActiveOpenByGridCells(any()) } returns emptyList()
+        // identityPort가 userId=99를 차단 목록으로 반환 → dogId=10 매핑
+        every { walkRepository.findDogIdsByUserIds(listOf(99L)) } returns listOf(10L)
+        coEvery { identityPort.getBlockedUserIds(1L) } returns listOf(99L)
 
         val result = handler.execute(
             GetNearbyPatternsUseCase.Query(gridCell = "10:20", userId = 1L, blockedUserIds = emptyList())
         )
 
         assertEquals(1, result.size)
+        assertEquals(20L, result[0].dogId)
     }
 
     @Test

--- a/services/walks/src/test/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternRepositoryIntegrationTest.kt
+++ b/services/walks/src/test/kotlin/com/mungcle/walks/infrastructure/persistence/WalkPatternRepositoryIntegrationTest.kt
@@ -1,0 +1,199 @@
+package com.mungcle.walks.infrastructure.persistence
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Testcontainers + JDBC 기반 walk_patterns 테이블 integration 테스트.
+ * upsert 및 집계 쿼리를 실제 PostgreSQL에서 검증한다.
+ */
+@Testcontainers
+class WalkPatternRepositoryIntegrationTest {
+
+    companion object {
+        private val idSeq = AtomicLong(9000L)
+
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("mungcle_test")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/migration/V1__init_walks_schema.sql")
+
+        private lateinit var conn: Connection
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            conn = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+            conn.autoCommit = true
+            // V2 마이그레이션 수동 적용
+            conn.createStatement().execute(
+                """
+                CREATE TABLE IF NOT EXISTS walks.walk_patterns (
+                    id          BIGINT PRIMARY KEY,
+                    grid_cell   VARCHAR(20) NOT NULL,
+                    hour_of_day INTEGER NOT NULL CHECK (hour_of_day BETWEEN 0 AND 23),
+                    dog_id      BIGINT NOT NULL,
+                    walk_count  INTEGER NOT NULL DEFAULT 1,
+                    last_walked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    UNIQUE (grid_cell, hour_of_day, dog_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_walk_patterns_grid_hour ON walks.walk_patterns (grid_cell, hour_of_day);
+                """.trimIndent()
+            )
+        }
+    }
+
+    @BeforeEach
+    fun cleanup() {
+        conn.createStatement().execute("DELETE FROM walks.walk_patterns")
+    }
+
+    private fun insertPattern(
+        dogId: Long = 10L,
+        gridCell: String = "100:200",
+        hourOfDay: Int = 10,
+        walkCount: Int = 1,
+        lastWalkedAt: Instant = Instant.now(),
+    ): Long {
+        val id = idSeq.getAndIncrement()
+        val ps = conn.prepareStatement(
+            """INSERT INTO walks.walk_patterns (id, grid_cell, hour_of_day, dog_id, walk_count, last_walked_at)
+               VALUES (?, ?, ?, ?, ?, ?)"""
+        )
+        ps.setLong(1, id)
+        ps.setString(2, gridCell)
+        ps.setInt(3, hourOfDay)
+        ps.setLong(4, dogId)
+        ps.setInt(5, walkCount)
+        ps.setTimestamp(6, Timestamp.from(lastWalkedAt))
+        ps.executeUpdate()
+        return id
+    }
+
+    private fun upsertPattern(
+        id: Long,
+        gridCell: String,
+        hourOfDay: Int,
+        dogId: Long,
+        walkedAt: Instant,
+    ) {
+        val ps = conn.prepareStatement(
+            """INSERT INTO walks.walk_patterns (id, grid_cell, hour_of_day, dog_id, walk_count, last_walked_at)
+               VALUES (?, ?, ?, ?, 1, ?)
+               ON CONFLICT (grid_cell, hour_of_day, dog_id)
+               DO UPDATE SET walk_count = walks.walk_patterns.walk_count + 1,
+                             last_walked_at = EXCLUDED.last_walked_at"""
+        )
+        ps.setLong(1, id)
+        ps.setString(2, gridCell)
+        ps.setInt(3, hourOfDay)
+        ps.setLong(4, dogId)
+        ps.setTimestamp(5, Timestamp.from(walkedAt))
+        ps.executeUpdate()
+    }
+
+    private fun queryByGridCellAndHour(gridCells: List<String>, minHour: Int, maxHour: Int): List<Map<String, Any?>> {
+        val placeholders = gridCells.joinToString(",") { "?" }
+        val ps = conn.prepareStatement(
+            "SELECT * FROM walks.walk_patterns WHERE grid_cell IN ($placeholders) AND hour_of_day BETWEEN ? AND ? ORDER BY walk_count DESC"
+        )
+        gridCells.forEachIndexed { i, cell -> ps.setString(i + 1, cell) }
+        ps.setInt(gridCells.size + 1, minHour)
+        ps.setInt(gridCells.size + 2, maxHour)
+        val rs = ps.executeQuery()
+        val results = mutableListOf<Map<String, Any?>>()
+        while (rs.next()) {
+            results.add(mapOf(
+                "id" to rs.getLong("id"),
+                "dog_id" to rs.getLong("dog_id"),
+                "grid_cell" to rs.getString("grid_cell"),
+                "hour_of_day" to rs.getInt("hour_of_day"),
+                "walk_count" to rs.getInt("walk_count"),
+                "last_walked_at" to rs.getTimestamp("last_walked_at").toInstant(),
+            ))
+        }
+        return results
+    }
+
+    @Test
+    fun `upsert — 새 레코드 삽입`() {
+        val now = Instant.now()
+        upsertPattern(idSeq.getAndIncrement(), "100:200", 10, 10L, now)
+
+        val results = queryByGridCellAndHour(listOf("100:200"), 9, 11)
+        assertEquals(1, results.size)
+        assertEquals(1, results[0]["walk_count"])
+        assertEquals(10L, results[0]["dog_id"])
+    }
+
+    @Test
+    fun `upsert — 중복 시 walk_count 증가 및 last_walked_at 갱신`() {
+        val id = idSeq.getAndIncrement()
+        val first = Instant.now().minusSeconds(3600)
+        val second = Instant.now()
+        upsertPattern(id, "100:200", 10, 10L, first)
+        upsertPattern(idSeq.getAndIncrement(), "100:200", 10, 10L, second)
+
+        val results = queryByGridCellAndHour(listOf("100:200"), 9, 11)
+        assertEquals(1, results.size)
+        assertEquals(2, results[0]["walk_count"])
+        // last_walked_at은 두 번째 값으로 갱신
+        val storedAt = results[0]["last_walked_at"] as Instant
+        assertTrue(storedAt >= first)
+    }
+
+    @Test
+    fun `시간 범위 필터 — 범위 밖 hourOfDay 제외`() {
+        insertPattern(dogId = 10L, gridCell = "100:200", hourOfDay = 10, walkCount = 5)
+        insertPattern(dogId = 20L, gridCell = "100:200", hourOfDay = 14, walkCount = 3)
+
+        val results = queryByGridCellAndHour(listOf("100:200"), 9, 11)
+        assertEquals(1, results.size)
+        assertEquals(10L, results[0]["dog_id"])
+    }
+
+    @Test
+    fun `그리드 셀 필터 — 대상 셀만 반환`() {
+        insertPattern(dogId = 10L, gridCell = "100:200", hourOfDay = 10)
+        insertPattern(dogId = 20L, gridCell = "999:999", hourOfDay = 10)
+
+        val results = queryByGridCellAndHour(listOf("100:200"), 9, 11)
+        assertEquals(1, results.size)
+        assertEquals(10L, results[0]["dog_id"])
+    }
+
+    @Test
+    fun `walk_count 기준 내림차순 정렬`() {
+        insertPattern(dogId = 10L, gridCell = "100:200", hourOfDay = 10, walkCount = 3)
+        insertPattern(dogId = 20L, gridCell = "100:200", hourOfDay = 10, walkCount = 7)
+        insertPattern(dogId = 30L, gridCell = "100:200", hourOfDay = 10, walkCount = 1)
+
+        val results = queryByGridCellAndHour(listOf("100:200"), 9, 11)
+        assertEquals(3, results.size)
+        assertEquals(7, results[0]["walk_count"])
+        assertEquals(3, results[1]["walk_count"])
+        assertEquals(1, results[2]["walk_count"])
+    }
+
+    @Test
+    fun `idx_walk_patterns_grid_hour 인덱스 존재 확인`() {
+        val rs = conn.createStatement().executeQuery(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = 'walks' AND tablename = 'walk_patterns' AND indexname = 'idx_walk_patterns_grid_hour'"
+        )
+        assertTrue(rs.next(), "idx_walk_patterns_grid_hour 인덱스가 존재해야 합니다")
+    }
+}


### PR DESCRIPTION
## Summary
- WalkPattern 도메인 모델 + CRUD (upsert 패턴)
- GetNearbyPatterns RPC 구현 (3x3 그리드, ±1시간, 14일 필터, ACTIVE 중복 제외, top 10)
- ExpireWalks CRON (60초 주기, ACTIVE → ENDED 전환)
- Kafka `walk.expired` 이벤트 발행
- StartWalkCommandHandler에 패�� upsert 추가
- Flyway V2 마이그레이션 (walk_patterns 테이블)
- Unit 테스트 + Testcontainers Integration 테스트

## Task Reference
- plan-docs/tasks/05-walks-patterns-cron.md

## Test plan
- [x] `./gradlew :services:walks:clean :services:walks:test` 통과
- [ ] ±1시간 필터, 14일 경과 제외, ACTIVE 중복 제외, top 10
- [ ] CRON 만료 대상 찾기 + 이벤트 발행 검증
- [ ] WalkPattern upsert + 집계 쿼리

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>