### PR TITLE
feat(social): 메시지 전송 + CRON 만료 + Kafka 이벤트

### DIFF
--- a/services/social/src/main/kotlin/com/mungcle/social/application/command/ExpireGreetingsCommandHandler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/application/command/ExpireGreetingsCommandHandler.kt
@@ -1,0 +1,32 @@
+package com.mungcle.social.application.command
+
+import com.mungcle.social.domain.port.`in`.ExpireGreetingsUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class ExpireGreetingsCommandHandler(
+    private val greetingRepository: GreetingRepositoryPort,
+    private val eventPublisher: SocialEventPublisherPort,
+) : ExpireGreetingsUseCase {
+
+    @Transactional
+    override fun execute(now: Instant): Int {
+        val expiredPending = greetingRepository.findExpiredPending(now)
+            .map { it.expire() }
+
+        val expiredAccepted = greetingRepository.findExpiredAccepted(now)
+            .map { it.expire() }
+
+        val allExpired = expiredPending + expiredAccepted
+        if (allExpired.isEmpty()) return 0
+
+        greetingRepository.saveAll(allExpired)
+        allExpired.forEach { eventPublisher.publishGreetingExpired(it) }
+
+        return allExpired.size
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/application/command/SendMessageCommandHandler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/application/command/SendMessageCommandHandler.kt
@@ -1,0 +1,52 @@
+package com.mungcle.social.application.command
+
+import com.mungcle.social.domain.exception.GreetingAccessDeniedException
+import com.mungcle.social.domain.exception.GreetingNotAcceptedException
+import com.mungcle.social.domain.exception.GreetingNotFoundException
+import com.mungcle.social.domain.exception.MessageTooLongException
+import com.mungcle.social.domain.model.Message
+import com.mungcle.social.domain.port.`in`.SendMessageUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.MessageRepositoryPort
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class SendMessageCommandHandler(
+    private val greetingRepository: GreetingRepositoryPort,
+    private val messageRepository: MessageRepositoryPort,
+    private val eventPublisher: SocialEventPublisherPort,
+) : SendMessageUseCase {
+
+    @Transactional
+    override fun execute(command: SendMessageUseCase.Command): Message {
+        val trimmed = command.body.trim()
+        if (trimmed.isEmpty() || trimmed.length > 140) throw MessageTooLongException(trimmed.length)
+
+        val greeting = greetingRepository.findById(command.greetingId)
+            ?: throw GreetingNotFoundException(command.greetingId)
+
+        val isParticipant = greeting.senderUserId == command.senderUserId ||
+            greeting.receiverUserId == command.senderUserId
+        if (!isParticipant) throw GreetingAccessDeniedException(command.greetingId)
+
+        val now = Instant.now()
+        if (!greeting.canSendMessage(now)) throw GreetingNotAcceptedException(command.greetingId)
+
+        val message = Message(
+            greetingId = command.greetingId,
+            senderUserId = command.senderUserId,
+            body = trimmed,
+        )
+        val saved = messageRepository.save(message)
+        val receiverUserId = if (greeting.senderUserId == command.senderUserId) {
+            greeting.receiverUserId
+        } else {
+            greeting.senderUserId
+        }
+        eventPublisher.publishMessageSent(saved, receiverUserId)
+        return saved
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/application/query/ListMessagesQueryHandler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/application/query/ListMessagesQueryHandler.kt
@@ -1,0 +1,27 @@
+package com.mungcle.social.application.query
+
+import com.mungcle.social.domain.exception.GreetingAccessDeniedException
+import com.mungcle.social.domain.exception.GreetingNotFoundException
+import com.mungcle.social.domain.model.Message
+import com.mungcle.social.domain.port.`in`.ListMessagesUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.MessageRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class ListMessagesQueryHandler(
+    private val greetingRepository: GreetingRepositoryPort,
+    private val messageRepository: MessageRepositoryPort,
+) : ListMessagesUseCase {
+
+    override fun execute(query: ListMessagesUseCase.Query): List<Message> {
+        val greeting = greetingRepository.findById(query.greetingId)
+            ?: throw GreetingNotFoundException(query.greetingId)
+
+        val isParticipant = greeting.senderUserId == query.userId ||
+            greeting.receiverUserId == query.userId
+        if (!isParticipant) throw GreetingAccessDeniedException(query.greetingId)
+
+        return messageRepository.findByGreetingId(query.greetingId)
+    }
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/exception/SocialExceptions.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/exception/SocialExceptions.kt
@@ -16,3 +16,7 @@ class ForbiddenBlockedException(userId: Long) : SocialException("User $userId is
 class SelfGreetingException(userId: Long) : SocialException("User $userId cannot greet themselves")
 
 class GreetingAccessDeniedException(id: Long) : SocialException("Access denied to greeting $id")
+
+class GreetingNotAcceptedException(id: Long) : SocialException("Greeting $id is not accepted or has expired")
+
+class MessageTooLongException(length: Int) : SocialException("Message length $length exceeds limit of 140 characters")

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/model/Greeting.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/model/Greeting.kt
@@ -25,9 +25,11 @@ data class Greeting(
     }
 
     fun expire(): Greeting {
-        if (status != GreetingStatus.PENDING) throw GreetingNotPendingException(id)
+        if (status != GreetingStatus.PENDING && status != GreetingStatus.ACCEPTED) throw GreetingNotPendingException(id)
         return copy(status = GreetingStatus.EXPIRED)
     }
+
+    fun canSendMessage(now: Instant): Boolean = status == GreetingStatus.ACCEPTED && now.isBefore(expiresAt)
 
     fun isPending(): Boolean = status == GreetingStatus.PENDING
 

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/model/Message.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/model/Message.kt
@@ -1,0 +1,11 @@
+package com.mungcle.social.domain.model
+
+import java.time.Instant
+
+data class Message(
+    val id: Long = 0,
+    val greetingId: Long,
+    val senderUserId: Long,
+    val body: String,
+    val createdAt: Instant = Instant.now(),
+)

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/ExpireGreetingsUseCase.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/ExpireGreetingsUseCase.kt
@@ -1,0 +1,8 @@
+package com.mungcle.social.domain.port.`in`
+
+import java.time.Instant
+
+interface ExpireGreetingsUseCase {
+    /** 만료 처리하고 만료된 건수를 반환한다. */
+    fun execute(now: Instant): Int
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/ListMessagesUseCase.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/ListMessagesUseCase.kt
@@ -1,0 +1,12 @@
+package com.mungcle.social.domain.port.`in`
+
+import com.mungcle.social.domain.model.Message
+
+interface ListMessagesUseCase {
+    fun execute(query: Query): List<Message>
+
+    data class Query(
+        val greetingId: Long,
+        val userId: Long,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/SendMessageUseCase.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/in/SendMessageUseCase.kt
@@ -1,0 +1,13 @@
+package com.mungcle.social.domain.port.`in`
+
+import com.mungcle.social.domain.model.Message
+
+interface SendMessageUseCase {
+    fun execute(command: Command): Message
+
+    data class Command(
+        val greetingId: Long,
+        val senderUserId: Long,
+        val body: String,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/GreetingRepositoryPort.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/GreetingRepositoryPort.kt
@@ -2,6 +2,7 @@ package com.mungcle.social.domain.port.out
 
 import com.mungcle.social.domain.model.Greeting
 import com.mungcle.social.domain.model.GreetingStatus
+import java.time.Instant
 
 /**
  * Greeting 영속성 포트.
@@ -11,6 +12,9 @@ interface GreetingRepositoryPort {
     /** Greeting을 저장하고 저장된 Greeting을 반환한다. */
     fun save(greeting: Greeting): Greeting
 
+    /** 여러 Greeting을 저장하고 저장된 목록을 반환한다. */
+    fun saveAll(greetings: List<Greeting>): List<Greeting>
+
     /** ID로 Greeting을 조회한다. 없으면 null. */
     fun findById(id: Long): Greeting?
 
@@ -19,4 +23,10 @@ interface GreetingRepositoryPort {
 
     /** 사용자 ID와 선택적 필터로 Greeting 목록을 조회한다. */
     fun findByUserId(userId: Long, statusFilter: GreetingStatus?, isSender: Boolean?): List<Greeting>
+
+    /** PENDING 상태이고 expiresAt이 now 이전인 Greeting 목록을 반환한다. */
+    fun findExpiredPending(now: Instant): List<Greeting>
+
+    /** ACCEPTED 상태이고 expiresAt이 now 이전인 Greeting 목록을 반환한다. */
+    fun findExpiredAccepted(now: Instant): List<Greeting>
 }

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/MessageRepositoryPort.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/MessageRepositoryPort.kt
@@ -1,0 +1,8 @@
+package com.mungcle.social.domain.port.out
+
+import com.mungcle.social.domain.model.Message
+
+interface MessageRepositoryPort {
+    fun save(message: Message): Message
+    fun findByGreetingId(greetingId: Long): List<Message>
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/SocialEventPublisherPort.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/domain/port/out/SocialEventPublisherPort.kt
@@ -1,6 +1,7 @@
 package com.mungcle.social.domain.port.out
 
 import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.Message
 
 /**
  * 소셜 이벤트 발행 포트.
@@ -12,4 +13,10 @@ interface SocialEventPublisherPort {
 
     /** 인사 수락 이벤트를 발행한다. */
     fun publishGreetingAccepted(greeting: Greeting)
+
+    /** 메시지 전송 이벤트를 발행한다. */
+    fun publishMessageSent(message: Message, receiverUserId: Long)
+
+    /** 인사 만료 이벤트를 발행한다. */
+    fun publishGreetingExpired(greeting: Greeting)
 }

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialExceptionExtensions.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialExceptionExtensions.kt
@@ -4,8 +4,10 @@ import com.mungcle.social.domain.exception.ForbiddenBlockedException
 import com.mungcle.social.domain.exception.GreetingAccessDeniedException
 import com.mungcle.social.domain.exception.GreetingDuplicateException
 import com.mungcle.social.domain.exception.GreetingExpiredException
+import com.mungcle.social.domain.exception.GreetingNotAcceptedException
 import com.mungcle.social.domain.exception.GreetingNotFoundException
 import com.mungcle.social.domain.exception.GreetingNotPendingException
+import com.mungcle.social.domain.exception.MessageTooLongException
 import com.mungcle.social.domain.exception.SelfGreetingException
 import com.mungcle.social.domain.exception.SocialException
 import io.grpc.Status
@@ -16,7 +18,9 @@ fun SocialException.toStatusException(): StatusException = when (this) {
     is GreetingDuplicateException -> StatusException(Status.ALREADY_EXISTS.withDescription(message))
     is GreetingExpiredException -> StatusException(Status.FAILED_PRECONDITION.withDescription(message))
     is GreetingNotPendingException -> StatusException(Status.FAILED_PRECONDITION.withDescription(message))
+    is GreetingNotAcceptedException -> StatusException(Status.FAILED_PRECONDITION.withDescription(message))
     is ForbiddenBlockedException -> StatusException(Status.PERMISSION_DENIED.withDescription(message))
     is GreetingAccessDeniedException -> StatusException(Status.PERMISSION_DENIED.withDescription(message))
     is SelfGreetingException -> StatusException(Status.INVALID_ARGUMENT.withDescription(message))
+    is MessageTooLongException -> StatusException(Status.INVALID_ARGUMENT.withDescription(message))
 }

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialGrpcService.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/grpc/server/SocialGrpcService.kt
@@ -15,14 +15,18 @@ import com.mungcle.proto.social.v1.MessageInfo
 import com.mungcle.proto.social.v1.SocialServiceGrpcKt
 import com.mungcle.proto.social.v1.greetingInfo
 import com.mungcle.proto.social.v1.listGreetingsResponse
+import com.mungcle.proto.social.v1.listMessagesResponse
+import com.mungcle.proto.social.v1.messageInfo
 import com.mungcle.social.domain.exception.SocialException
 import com.mungcle.social.domain.model.Greeting
 import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.model.Message
 import com.mungcle.social.domain.port.`in`.CreateGreetingUseCase
 import com.mungcle.social.domain.port.`in`.GetGreetingUseCase
 import com.mungcle.social.domain.port.`in`.ListGreetingsUseCase
+import com.mungcle.social.domain.port.`in`.ListMessagesUseCase
 import com.mungcle.social.domain.port.`in`.RespondGreetingUseCase
-import io.grpc.Status
+import com.mungcle.social.domain.port.`in`.SendMessageUseCase
 import io.grpc.StatusException
 import net.devh.boot.grpc.server.service.GrpcService
 
@@ -32,6 +36,8 @@ class SocialGrpcService(
     private val respondGreetingUseCase: RespondGreetingUseCase,
     private val getGreetingUseCase: GetGreetingUseCase,
     private val listGreetingsUseCase: ListGreetingsUseCase,
+    private val sendMessageUseCase: SendMessageUseCase,
+    private val listMessagesUseCase: ListMessagesUseCase,
 ) : SocialServiceGrpcKt.SocialServiceCoroutineImplBase() {
 
     override suspend fun createGreeting(request: CreateGreetingRequest): GreetingInfo {
@@ -104,11 +110,42 @@ class SocialGrpcService(
     }
 
     override suspend fun sendMessage(request: SendMessageRequest): MessageInfo {
-        throw StatusException(Status.UNIMPLEMENTED.withDescription("태스크 08에서 구현 예정"))
+        try {
+            val message = sendMessageUseCase.execute(
+                SendMessageUseCase.Command(
+                    greetingId = request.greetingId,
+                    senderUserId = request.senderUserId,
+                    body = request.body,
+                )
+            )
+            return message.toMessageInfo()
+        } catch (e: SocialException) {
+            throw e.toStatusException()
+        }
     }
 
     override suspend fun listMessages(request: ListMessagesRequest): ListMessagesResponse {
-        throw StatusException(Status.UNIMPLEMENTED.withDescription("태스크 08에서 구현 예정"))
+        try {
+            val messages = listMessagesUseCase.execute(
+                ListMessagesUseCase.Query(
+                    greetingId = request.greetingId,
+                    userId = request.userId,
+                )
+            )
+            return listMessagesResponse {
+                this.messages += messages.map { it.toMessageInfo() }
+            }
+        } catch (e: SocialException) {
+            throw e.toStatusException()
+        }
+    }
+
+    private fun Message.toMessageInfo(): MessageInfo = messageInfo {
+        id = this@toMessageInfo.id
+        greetingId = this@toMessageInfo.greetingId
+        senderUserId = this@toMessageInfo.senderUserId
+        body = this@toMessageInfo.body
+        createdAt = this@toMessageInfo.createdAt.epochSecond
     }
 
     private fun Greeting.toGreetingInfo(): GreetingInfo = greetingInfo {

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/kafka/SocialEventPublisher.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/kafka/SocialEventPublisher.kt
@@ -2,8 +2,12 @@ package com.mungcle.social.infrastructure.kafka
 
 import com.mungcle.common.kafka.GreetingAcceptedEvent
 import com.mungcle.common.kafka.GreetingCreatedEvent
+import com.mungcle.common.kafka.GreetingExpiredEvent
+import com.mungcle.common.kafka.MessageSentEvent
 import com.mungcle.common.kafka.Topics
 import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.model.Message
 import com.mungcle.social.domain.port.out.SocialEventPublisherPort
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
@@ -29,5 +33,27 @@ class SocialEventPublisher(
             receiverUserId = greeting.receiverUserId,
         )
         kafkaTemplate.send(Topics.GREETING_ACCEPTED, greeting.id.toString(), event)
+    }
+
+    override fun publishMessageSent(message: Message, receiverUserId: Long) {
+        val event = MessageSentEvent(
+            messageId = message.id,
+            greetingId = message.greetingId,
+            senderUserId = message.senderUserId,
+            receiverUserId = receiverUserId,
+        )
+        kafkaTemplate.send(Topics.MESSAGE_SENT, message.id.toString(), event)
+    }
+
+    override fun publishGreetingExpired(greeting: Greeting) {
+        val expiredType = when (greeting.status) {
+            GreetingStatus.EXPIRED -> if (greeting.respondedAt != null) "ACCEPTED" else "PENDING"
+            else -> "PENDING"
+        }
+        val event = GreetingExpiredEvent(
+            greetingId = greeting.id,
+            expiredType = expiredType,
+        )
+        kafkaTemplate.send(Topics.GREETING_EXPIRED, greeting.id.toString(), event)
     }
 }

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingRepositoryAdapter.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingRepositoryAdapter.kt
@@ -4,6 +4,7 @@ import com.mungcle.social.domain.model.Greeting
 import com.mungcle.social.domain.model.GreetingStatus
 import com.mungcle.social.domain.port.out.GreetingRepositoryPort
 import org.springframework.stereotype.Repository
+import java.time.Instant
 
 @Repository
 class GreetingRepositoryAdapter(
@@ -16,6 +17,11 @@ class GreetingRepositoryAdapter(
         return GreetingMapper.toDomain(saved)
     }
 
+    override fun saveAll(greetings: List<Greeting>): List<Greeting> {
+        val entities = greetings.map(GreetingMapper::toEntity)
+        return springDataRepository.saveAll(entities).map(GreetingMapper::toDomain)
+    }
+
     override fun findById(id: Long): Greeting? =
         springDataRepository.findById(id).orElse(null)?.let(GreetingMapper::toDomain)
 
@@ -26,4 +32,10 @@ class GreetingRepositoryAdapter(
     override fun findByUserId(userId: Long, statusFilter: GreetingStatus?, isSender: Boolean?): List<Greeting> =
         springDataRepository.findByUserId(userId, statusFilter, isSender)
             .map(GreetingMapper::toDomain)
+
+    override fun findExpiredPending(now: Instant): List<Greeting> =
+        springDataRepository.findExpiredPending(now).map(GreetingMapper::toDomain)
+
+    override fun findExpiredAccepted(now: Instant): List<Greeting> =
+        springDataRepository.findExpiredAccepted(now).map(GreetingMapper::toDomain)
 }

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingSpringDataRepository.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/GreetingSpringDataRepository.kt
@@ -4,6 +4,7 @@ import com.mungcle.social.domain.model.GreetingStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.Instant
 import java.util.Optional
 
 interface GreetingSpringDataRepository : JpaRepository<GreetingEntity, Long> {
@@ -29,4 +30,10 @@ interface GreetingSpringDataRepository : JpaRepository<GreetingEntity, Long> {
         @Param("statusFilter") statusFilter: GreetingStatus?,
         @Param("isSender") isSender: Boolean?,
     ): List<GreetingEntity>
+
+    @Query("SELECT g FROM GreetingEntity g WHERE g.status = 'PENDING' AND g.expiresAt < :now")
+    fun findExpiredPending(@Param("now") now: Instant): List<GreetingEntity>
+
+    @Query("SELECT g FROM GreetingEntity g WHERE g.status = 'ACCEPTED' AND g.expiresAt < :now")
+    fun findExpiredAccepted(@Param("now") now: Instant): List<GreetingEntity>
 }

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/MessageEntity.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/MessageEntity.kt
@@ -1,0 +1,28 @@
+package com.mungcle.social.infrastructure.persistence
+
+import io.hypersistence.utils.hibernate.id.Tsid
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "messages", schema = "social")
+open class MessageEntity(
+    @Id
+    @Tsid
+    open var id: Long = 0,
+
+    @Column(name = "greeting_id", nullable = false)
+    open var greetingId: Long = 0,
+
+    @Column(name = "sender_user_id", nullable = false)
+    open var senderUserId: Long = 0,
+
+    @Column(name = "body", nullable = false, length = 140)
+    open var body: String = "",
+
+    @Column(name = "created_at", nullable = false)
+    open var createdAt: Instant = Instant.now(),
+)

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/MessageMapper.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/MessageMapper.kt
@@ -1,0 +1,22 @@
+package com.mungcle.social.infrastructure.persistence
+
+import com.mungcle.social.domain.model.Message
+
+object MessageMapper {
+
+    fun toDomain(entity: MessageEntity): Message = Message(
+        id = entity.id,
+        greetingId = entity.greetingId,
+        senderUserId = entity.senderUserId,
+        body = entity.body,
+        createdAt = entity.createdAt,
+    )
+
+    fun toEntity(domain: Message): MessageEntity = MessageEntity(
+        id = domain.id,
+        greetingId = domain.greetingId,
+        senderUserId = domain.senderUserId,
+        body = domain.body,
+        createdAt = domain.createdAt,
+    )
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/MessageRepositoryAdapter.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/MessageRepositoryAdapter.kt
@@ -1,0 +1,20 @@
+package com.mungcle.social.infrastructure.persistence
+
+import com.mungcle.social.domain.model.Message
+import com.mungcle.social.domain.port.out.MessageRepositoryPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class MessageRepositoryAdapter(
+    private val springDataRepository: MessageSpringDataRepository,
+) : MessageRepositoryPort {
+
+    override fun save(message: Message): Message {
+        val entity = MessageMapper.toEntity(message)
+        val saved = springDataRepository.save(entity)
+        return MessageMapper.toDomain(saved)
+    }
+
+    override fun findByGreetingId(greetingId: Long): List<Message> =
+        springDataRepository.findByGreetingId(greetingId).map(MessageMapper::toDomain)
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/MessageSpringDataRepository.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/persistence/MessageSpringDataRepository.kt
@@ -1,0 +1,11 @@
+package com.mungcle.social.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface MessageSpringDataRepository : JpaRepository<MessageEntity, Long> {
+
+    @Query("SELECT m FROM MessageEntity m WHERE m.greetingId = :greetingId ORDER BY m.createdAt ASC")
+    fun findByGreetingId(@Param("greetingId") greetingId: Long): List<MessageEntity>
+}

--- a/services/social/src/main/kotlin/com/mungcle/social/infrastructure/scheduler/GreetingExpiryScheduler.kt
+++ b/services/social/src/main/kotlin/com/mungcle/social/infrastructure/scheduler/GreetingExpiryScheduler.kt
@@ -1,0 +1,17 @@
+package com.mungcle.social.infrastructure.scheduler
+
+import com.mungcle.social.domain.port.`in`.ExpireGreetingsUseCase
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class GreetingExpiryScheduler(
+    private val expireGreetings: ExpireGreetingsUseCase,
+) {
+
+    @Scheduled(fixedRate = 60_000)
+    fun expire() {
+        expireGreetings.execute(Instant.now())
+    }
+}

--- a/services/social/src/main/resources/db/migration/V2__add_messages.sql
+++ b/services/social/src/main/resources/db/migration/V2__add_messages.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS social.messages (
+    id              BIGINT PRIMARY KEY,
+    greeting_id     BIGINT NOT NULL REFERENCES social.greetings(id),
+    sender_user_id  BIGINT NOT NULL,
+    body            VARCHAR(140) NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_messages_greeting ON social.messages (greeting_id, created_at);

--- a/services/social/src/test/kotlin/com/mungcle/social/application/command/ExpireGreetingsCommandHandlerTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/application/command/ExpireGreetingsCommandHandlerTest.kt
@@ -1,0 +1,105 @@
+package com.mungcle.social.application.command
+
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.port.`in`.ExpireGreetingsUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class ExpireGreetingsCommandHandlerTest {
+
+    private val greetingRepository: GreetingRepositoryPort = mockk()
+    private val eventPublisher: SocialEventPublisherPort = mockk(relaxed = true)
+
+    private val handler = ExpireGreetingsCommandHandler(
+        greetingRepository = greetingRepository,
+        eventPublisher = eventPublisher,
+    )
+
+    private fun pendingGreeting(id: Long) = Greeting(
+        id = id,
+        senderUserId = 10L,
+        senderDogId = 100L,
+        receiverUserId = 20L,
+        receiverDogId = 200L,
+        receiverWalkId = 300L + id,
+        status = GreetingStatus.PENDING,
+        expiresAt = Instant.now().minusSeconds(1),
+    )
+
+    private fun acceptedGreeting(id: Long) = Greeting(
+        id = id,
+        senderUserId = 10L,
+        senderDogId = 100L,
+        receiverUserId = 20L,
+        receiverDogId = 200L,
+        receiverWalkId = 400L + id,
+        status = GreetingStatus.ACCEPTED,
+        respondedAt = Instant.now().minusSeconds(1800),
+        expiresAt = Instant.now().minusSeconds(1),
+    )
+
+    @Test
+    fun `PENDING 만료 — 5건 처리되고 이벤트 발행`() {
+        val now = Instant.now()
+        val pending = (1L..5L).map { pendingGreeting(it) }
+        every { greetingRepository.findExpiredPending(now) } returns pending
+        every { greetingRepository.findExpiredAccepted(now) } returns emptyList()
+        every { greetingRepository.saveAll(any()) } answers { firstArg() }
+
+        val count = handler.execute(now)
+
+        assertEquals(5, count)
+        verify(exactly = 5) { eventPublisher.publishGreetingExpired(any()) }
+    }
+
+    @Test
+    fun `ACCEPTED 만료 — 3건 처리되고 이벤트 발행`() {
+        val now = Instant.now()
+        val accepted = (10L..12L).map { acceptedGreeting(it) }
+        every { greetingRepository.findExpiredPending(now) } returns emptyList()
+        every { greetingRepository.findExpiredAccepted(now) } returns accepted
+        every { greetingRepository.saveAll(any()) } answers { firstArg() }
+
+        val count = handler.execute(now)
+
+        assertEquals(3, count)
+        verify(exactly = 3) { eventPublisher.publishGreetingExpired(any()) }
+    }
+
+    @Test
+    fun `만료 없음 — 0 반환, 이벤트 미발행`() {
+        val now = Instant.now()
+        every { greetingRepository.findExpiredPending(now) } returns emptyList()
+        every { greetingRepository.findExpiredAccepted(now) } returns emptyList()
+
+        val count = handler.execute(now)
+
+        assertEquals(0, count)
+        verify(exactly = 0) { eventPublisher.publishGreetingExpired(any()) }
+    }
+
+    @Test
+    fun `PENDING + ACCEPTED 혼합 만료 — 이벤트 각각 발행`() {
+        val now = Instant.now()
+        val pending = listOf(pendingGreeting(1L), pendingGreeting(2L))
+        val accepted = listOf(acceptedGreeting(10L))
+        every { greetingRepository.findExpiredPending(now) } returns pending
+        every { greetingRepository.findExpiredAccepted(now) } returns accepted
+        val savedSlot = slot<List<Greeting>>()
+        every { greetingRepository.saveAll(capture(savedSlot)) } answers { firstArg() }
+
+        val count = handler.execute(now)
+
+        assertEquals(3, count)
+        verify(exactly = 3) { eventPublisher.publishGreetingExpired(any()) }
+        assertEquals(3, savedSlot.captured.size)
+    }
+}

--- a/services/social/src/test/kotlin/com/mungcle/social/application/command/SendMessageCommandHandlerTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/application/command/SendMessageCommandHandlerTest.kt
@@ -1,0 +1,111 @@
+package com.mungcle.social.application.command
+
+import com.mungcle.social.domain.exception.GreetingAccessDeniedException
+import com.mungcle.social.domain.exception.GreetingNotAcceptedException
+import com.mungcle.social.domain.exception.MessageTooLongException
+import com.mungcle.social.domain.model.Greeting
+import com.mungcle.social.domain.model.GreetingStatus
+import com.mungcle.social.domain.model.Message
+import com.mungcle.social.domain.port.`in`.SendMessageUseCase
+import com.mungcle.social.domain.port.out.GreetingRepositoryPort
+import com.mungcle.social.domain.port.out.MessageRepositoryPort
+import com.mungcle.social.domain.port.out.SocialEventPublisherPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class SendMessageCommandHandlerTest {
+
+    private val greetingRepository: GreetingRepositoryPort = mockk()
+    private val messageRepository: MessageRepositoryPort = mockk()
+    private val eventPublisher: SocialEventPublisherPort = mockk(relaxed = true)
+
+    private val handler = SendMessageCommandHandler(
+        greetingRepository = greetingRepository,
+        messageRepository = messageRepository,
+        eventPublisher = eventPublisher,
+    )
+
+    private fun acceptedGreeting(
+        id: Long = 1L,
+        senderUserId: Long = 10L,
+        receiverUserId: Long = 20L,
+        expiresAt: Instant = Instant.now().plusSeconds(1800),
+    ) = Greeting(
+        id = id,
+        senderUserId = senderUserId,
+        senderDogId = 100L,
+        receiverUserId = receiverUserId,
+        receiverDogId = 200L,
+        receiverWalkId = 300L,
+        status = GreetingStatus.ACCEPTED,
+        respondedAt = Instant.now().minusSeconds(60),
+        expiresAt = expiresAt,
+    )
+
+    @Test
+    fun `정상 메시지 전송`() {
+        val greeting = acceptedGreeting()
+        every { greetingRepository.findById(1L) } returns greeting
+        val slot = slot<Message>()
+        every { messageRepository.save(capture(slot)) } answers { slot.captured.copy(id = 100L) }
+
+        val result = handler.execute(SendMessageUseCase.Command(1L, 10L, "안녕하세요"))
+
+        assertEquals(100L, result.id)
+        assertEquals(1L, result.greetingId)
+        assertEquals(10L, result.senderUserId)
+        assertEquals("안녕하세요", result.body)
+        verify { eventPublisher.publishMessageSent(any(), any()) }
+    }
+
+    @Test
+    fun `140자 초과 메시지 → MessageTooLongException`() {
+        val longBody = "a".repeat(141)
+
+        assertThrows<MessageTooLongException> {
+            handler.execute(SendMessageUseCase.Command(1L, 10L, longBody))
+        }
+    }
+
+    @Test
+    fun `빈 문자열 메시지 → MessageTooLongException`() {
+        assertThrows<MessageTooLongException> {
+            handler.execute(SendMessageUseCase.Command(1L, 10L, "   "))
+        }
+    }
+
+    @Test
+    fun `PENDING 상태 인사에 메시지 → GreetingNotAcceptedException`() {
+        val pendingGreeting = Greeting(
+            id = 1L,
+            senderUserId = 10L,
+            senderDogId = 100L,
+            receiverUserId = 20L,
+            receiverDogId = 200L,
+            receiverWalkId = 300L,
+            status = GreetingStatus.PENDING,
+            expiresAt = Instant.now().plusSeconds(300),
+        )
+        every { greetingRepository.findById(1L) } returns pendingGreeting
+
+        assertThrows<GreetingNotAcceptedException> {
+            handler.execute(SendMessageUseCase.Command(1L, 10L, "안녕하세요"))
+        }
+    }
+
+    @Test
+    fun `비참여자가 메시지 전송 → GreetingAccessDeniedException`() {
+        val greeting = acceptedGreeting()
+        every { greetingRepository.findById(1L) } returns greeting
+
+        assertThrows<GreetingAccessDeniedException> {
+            handler.execute(SendMessageUseCase.Command(1L, senderUserId = 99L, "안녕하세요"))
+        }
+    }
+}

--- a/services/social/src/test/kotlin/com/mungcle/social/domain/model/GreetingTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/domain/model/GreetingTest.kt
@@ -76,12 +76,19 @@ class GreetingTest {
     }
 
     @Test
-    fun `expire — PENDING이 아니면 GreetingNotPendingException`() {
-        val accepted = pendingGreeting().accept(Instant.now())
+    fun `expire — EXPIRED 상태이면 GreetingNotPendingException`() {
+        val expired = pendingGreeting().expire()
 
         assertThrows<GreetingNotPendingException> {
-            accepted.expire()
+            expired.expire()
         }
+    }
+
+    @Test
+    fun `expire — ACCEPTED 상태에서도 EXPIRED로 전이`() {
+        val accepted = pendingGreeting().accept(Instant.now())
+        val expired = accepted.expire()
+        assertEquals(GreetingStatus.EXPIRED, expired.status)
     }
 
     @Test
@@ -96,5 +103,25 @@ class GreetingTest {
         val future = Instant.now().plusSeconds(300)
         val greeting = pendingGreeting(expiresAt = future)
         assertFalse(greeting.isExpired(Instant.now()))
+    }
+
+    @Test
+    fun `canSendMessage — ACCEPTED이고 미만료이면 true`() {
+        val now = Instant.now()
+        val accepted = pendingGreeting(expiresAt = now.plusSeconds(1800)).accept(now)
+        assertTrue(accepted.canSendMessage(now.plusSeconds(60)))
+    }
+
+    @Test
+    fun `canSendMessage — ACCEPTED이지만 만료이면 false`() {
+        val now = Instant.now()
+        val accepted = pendingGreeting(expiresAt = now.plusSeconds(1800)).accept(now)
+        assertFalse(accepted.canSendMessage(now.plusSeconds(1801)))
+    }
+
+    @Test
+    fun `canSendMessage — PENDING이면 false`() {
+        val greeting = pendingGreeting()
+        assertFalse(greeting.canSendMessage(Instant.now()))
     }
 }

--- a/services/social/src/test/kotlin/com/mungcle/social/infrastructure/persistence/MessageRepositoryIntegrationTest.kt
+++ b/services/social/src/test/kotlin/com/mungcle/social/infrastructure/persistence/MessageRepositoryIntegrationTest.kt
@@ -1,0 +1,143 @@
+package com.mungcle.social.infrastructure.persistence
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Testcontainers + JDBC 기반 Message 테이블 integration 테스트.
+ * V1 + V2 마이그레이션을 적용하여 save, findByGreetingId를 검증한다.
+ */
+@Testcontainers
+class MessageRepositoryIntegrationTest {
+
+    companion object {
+        private val idSeq = AtomicLong(2000L)
+
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("mungcle_test")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("db/migration/V1__init_social_schema.sql")
+
+        private lateinit var conn: Connection
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            conn = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+            conn.autoCommit = true
+            // V2 마이그레이션 수동 적용
+            conn.createStatement().execute(
+                """
+                CREATE TABLE IF NOT EXISTS social.messages (
+                    id              BIGINT PRIMARY KEY,
+                    greeting_id     BIGINT NOT NULL REFERENCES social.greetings(id),
+                    sender_user_id  BIGINT NOT NULL,
+                    body            VARCHAR(140) NOT NULL,
+                    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                );
+                CREATE INDEX IF NOT EXISTS idx_messages_greeting ON social.messages (greeting_id, created_at);
+                """.trimIndent()
+            )
+        }
+    }
+
+    @BeforeEach
+    fun cleanup() {
+        conn.createStatement().execute("DELETE FROM social.messages")
+        conn.createStatement().execute("DELETE FROM social.greetings")
+    }
+
+    private fun insertGreeting(
+        id: Long = idSeq.getAndIncrement(),
+        senderUserId: Long = 10L,
+        receiverUserId: Long = 20L,
+        receiverWalkId: Long = 300L,
+    ): Long {
+        val ps = conn.prepareStatement(
+            """INSERT INTO social.greetings
+               (id, sender_user_id, sender_dog_id, receiver_user_id, receiver_dog_id, receiver_walk_id,
+                status, created_at, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, 'ACCEPTED', NOW(), NOW() + INTERVAL '30 minutes')"""
+        )
+        ps.setLong(1, id)
+        ps.setLong(2, senderUserId)
+        ps.setLong(3, 100L)
+        ps.setLong(4, receiverUserId)
+        ps.setLong(5, 200L)
+        ps.setLong(6, receiverWalkId)
+        ps.executeUpdate()
+        return id
+    }
+
+    private fun insertMessage(
+        id: Long = idSeq.getAndIncrement(),
+        greetingId: Long,
+        senderUserId: Long = 10L,
+        body: String = "안녕하세요",
+        createdAt: Instant = Instant.now(),
+    ): Long {
+        val ps = conn.prepareStatement(
+            "INSERT INTO social.messages (id, greeting_id, sender_user_id, body, created_at) VALUES (?, ?, ?, ?, ?)"
+        )
+        ps.setLong(1, id)
+        ps.setLong(2, greetingId)
+        ps.setLong(3, senderUserId)
+        ps.setString(4, body)
+        ps.setTimestamp(5, Timestamp.from(createdAt))
+        ps.executeUpdate()
+        return id
+    }
+
+    @Test
+    fun `save — 메시지 저장 후 조회 가능`() {
+        val greetingId = insertGreeting()
+        val messageId = insertMessage(greetingId = greetingId, body = "반갑습니다")
+
+        val ps = conn.prepareStatement("SELECT * FROM social.messages WHERE id = ?")
+        ps.setLong(1, messageId)
+        val rs = ps.executeQuery()
+        assertTrue(rs.next())
+        assertEquals(greetingId, rs.getLong("greeting_id"))
+        assertEquals("반갑습니다", rs.getString("body"))
+        assertEquals(10L, rs.getLong("sender_user_id"))
+    }
+
+    @Test
+    fun `findByGreetingId — 동일 greeting의 메시지 목록 반환`() {
+        val greetingId = insertGreeting()
+        insertMessage(greetingId = greetingId, body = "첫 번째 메시지")
+        insertMessage(greetingId = greetingId, body = "두 번째 메시지")
+        insertMessage(greetingId = insertGreeting(receiverWalkId = 301L), body = "다른 greeting 메시지")
+
+        val ps = conn.prepareStatement(
+            "SELECT * FROM social.messages WHERE greeting_id = ? ORDER BY created_at"
+        )
+        ps.setLong(1, greetingId)
+        val rs = ps.executeQuery()
+        var count = 0
+        while (rs.next()) count++
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun `idx_messages_greeting 인덱스 존재 확인`() {
+        val rs = conn.createStatement().executeQuery(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = 'social' AND tablename = 'messages' AND indexname = 'idx_messages_greeting'"
+        )
+        assertTrue(rs.next(), "idx_messages_greeting 인덱스가 존재해야 합니다")
+    }
+}


### PR DESCRIPTION
## Summary
- Message 도메인 모델 + SendMessage/ListMessages 구현
- ExpireGreetings CRON (60초 주기, PENDING 5분 + ACCEPTED 30분 만료)
- Kafka 이벤트: `message.sent`, `greeting.expired`
- SocialGrpcService 확장 (SendMessage, ListMessages RPC)
- Flyway V2 마이그레이션 (messages 테이블)
- Unit 테스트 + Testcontainers Integration 테스트

## Task Reference
- plan-docs/tasks/08-social-messages-cron.md

## Test plan
- [x] `./gradlew :services:social:clean :services:social:test` 통과
- [ ] canSendMessage (ACCEPTED+미만료, ACCEPTED+만료, PENDING)
- [ ] 140자 초과 거부, 비참여자 거부
- [ ] CRON 만료 (PENDING 5분, ACCEPTED 30분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>