### PR TITLE
feat(gateway): Auth + Users + Dogs REST API + JWT 인증

### DIFF
--- a/services/api-gateway/build.gradle.kts
+++ b/services/api-gateway/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 dependencies {
     implementation(project(":common:domain-common"))
     implementation(project(":common:kafka-common"))
+    implementation(project(":common:grpc-client"))
 
     // Spring Boot
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -40,4 +41,5 @@ dependencies {
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.mockk:mockk:${property("mockkVersion")}")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
 }

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/AuthController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/AuthController.kt
@@ -1,0 +1,52 @@
+package com.mungcle.gateway.api
+
+import com.mungcle.gateway.dto.AuthResponseDto
+import com.mungcle.gateway.dto.KakaoLoginRequest
+import com.mungcle.gateway.dto.LoginRequest
+import com.mungcle.gateway.dto.PushTokenRequest
+import com.mungcle.gateway.dto.RegisterRequest
+import com.mungcle.gateway.dto.UserResponse
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.security.AuthUser
+import com.mungcle.proto.identity.v1.AuthResponse
+import jakarta.validation.Valid
+import kotlinx.coroutines.runBlocking
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/auth")
+class AuthController(private val identityClient: IdentityClient) {
+
+    @PostMapping("/kakao")
+    fun kakaoLogin(@Valid @RequestBody req: KakaoLoginRequest): AuthResponseDto = runBlocking {
+        identityClient.authenticateKakao(req.kakaoAccessToken).toDto()
+    }
+
+    @PostMapping("/email/register")
+    fun register(@Valid @RequestBody req: RegisterRequest): AuthResponseDto = runBlocking {
+        identityClient.registerEmail(req.email, req.password, req.nickname).toDto()
+    }
+
+    @PostMapping("/email/login")
+    fun login(@Valid @RequestBody req: LoginRequest): AuthResponseDto = runBlocking {
+        identityClient.loginEmail(req.email, req.password).toDto()
+    }
+
+    @PostMapping("/push-token")
+    fun updatePushToken(@AuthUser userId: Long, @Valid @RequestBody req: PushTokenRequest): Unit = runBlocking {
+        identityClient.updatePushToken(userId, req.pushToken)
+    }
+
+    private fun AuthResponse.toDto() = AuthResponseDto(
+        accessToken = accessToken,
+        user = UserResponse(
+            id = user.id,
+            nickname = user.nickname,
+            neighborhood = user.neighborhood,
+            profilePhotoUrl = user.profilePhotoUrl,
+        ),
+    )
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/BlockController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/BlockController.kt
@@ -1,0 +1,45 @@
+package com.mungcle.gateway.api
+
+import com.mungcle.gateway.dto.BlockResponse
+import com.mungcle.gateway.dto.CreateBlockRequest
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.security.AuthUser
+import jakarta.validation.Valid
+import kotlinx.coroutines.runBlocking
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/blocks")
+class BlockController(private val identityClient: IdentityClient) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createBlock(@AuthUser userId: Long, @Valid @RequestBody req: CreateBlockRequest): Unit = runBlocking {
+        identityClient.createBlock(blockerId = userId, blockedId = req.blockedUserId)
+    }
+
+    @DeleteMapping("/{blockedUserId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteBlock(@AuthUser userId: Long, @PathVariable blockedUserId: Long): Unit = runBlocking {
+        identityClient.deleteBlock(blockerId = userId, blockedId = blockedUserId)
+    }
+
+    @GetMapping
+    fun listBlocks(@AuthUser userId: Long): List<BlockResponse> = runBlocking {
+        identityClient.listBlocks(userId).blocksList.map { block ->
+            BlockResponse(
+                blockedUserId = block.blockedUserId,
+                blockedNickname = block.blockedNickname,
+                createdAt = block.createdAt,
+            )
+        }
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/DogController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/DogController.kt
@@ -1,0 +1,95 @@
+package com.mungcle.gateway.api
+
+import com.mungcle.gateway.dto.CreateDogRequest
+import com.mungcle.gateway.dto.DogResponse
+import com.mungcle.gateway.dto.UpdateDogRequest
+import com.mungcle.gateway.infrastructure.grpc.PetProfileClient
+import com.mungcle.gateway.infrastructure.security.AuthUser
+import com.mungcle.proto.petprofile.v1.DogInfo
+import com.mungcle.proto.petprofile.v1.DogSize
+import jakarta.validation.Valid
+import kotlinx.coroutines.runBlocking
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/dogs")
+class DogController(private val petProfileClient: PetProfileClient) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createDog(@AuthUser userId: Long, @Valid @RequestBody req: CreateDogRequest): DogResponse = runBlocking {
+        petProfileClient.createDog(
+            ownerId = userId,
+            dogName = req.name,
+            dogBreed = req.breed,
+            dogSize = parseDogSize(req.size),
+            dogTemperaments = req.temperaments,
+            dogSociability = req.sociability,
+            photoPath = req.photoPath,
+            vaccinationPhotoPath = req.vaccinationPhotoPath,
+        ).toResponse()
+    }
+
+    @GetMapping
+    fun getDogs(@AuthUser userId: Long): List<DogResponse> = runBlocking {
+        petProfileClient.getDogsByOwner(userId).map { it.toResponse() }
+    }
+
+    @GetMapping("/{id}")
+    fun getDog(@AuthUser userId: Long, @PathVariable id: Long): DogResponse = runBlocking {
+        petProfileClient.getDog(id).toResponse()
+    }
+
+    @PatchMapping("/{id}")
+    fun updateDog(
+        @AuthUser userId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody req: UpdateDogRequest,
+    ): DogResponse = runBlocking {
+        petProfileClient.updateDog(
+            dogId = id,
+            requesterId = userId,
+            dogName = req.name,
+            dogBreed = req.breed,
+            dogSize = req.size?.let { parseDogSize(it) },
+            dogTemperaments = req.temperaments,
+            dogSociability = req.sociability,
+            photoPath = req.photoPath,
+            vaccinationPhotoPath = req.vaccinationPhotoPath,
+        ).toResponse()
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteDog(@AuthUser userId: Long, @PathVariable id: Long): Unit = runBlocking {
+        petProfileClient.deleteDog(dogId = id, ownerId = userId)
+    }
+
+    private fun parseDogSize(size: String): DogSize = when (size.uppercase()) {
+        "SMALL" -> DogSize.DOG_SIZE_SMALL
+        "MEDIUM" -> DogSize.DOG_SIZE_MEDIUM
+        "LARGE" -> DogSize.DOG_SIZE_LARGE
+        else -> throw IllegalArgumentException("유효하지 않은 반려견 크기입니다: $size")
+    }
+
+    private fun DogInfo.toResponse() = DogResponse(
+        id = id,
+        ownerId = ownerId,
+        name = name,
+        breed = breed,
+        size = size.name.removePrefix("DOG_SIZE_"),
+        temperaments = temperamentsList,
+        sociability = sociability,
+        photoUrl = photoUrl,
+        vaccinationRegistered = vaccinationRegistered,
+    )
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/HealthController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/HealthController.kt
@@ -1,0 +1,13 @@
+package com.mungcle.gateway.api
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/health")
+class HealthController {
+
+    @GetMapping
+    fun health(): Map<String, String> = mapOf("status" to "UP")
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/ReportController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/ReportController.kt
@@ -1,0 +1,28 @@
+package com.mungcle.gateway.api
+
+import com.mungcle.gateway.dto.CreateReportRequest
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.security.AuthUser
+import jakarta.validation.Valid
+import kotlinx.coroutines.runBlocking
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/reports")
+class ReportController(private val identityClient: IdentityClient) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createReport(@AuthUser userId: Long, @Valid @RequestBody req: CreateReportRequest): Unit = runBlocking {
+        identityClient.createReport(
+            reporterId = userId,
+            reportedId = req.reportedUserId,
+            reason = req.reason,
+        )
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/UserController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/UserController.kt
@@ -1,0 +1,64 @@
+package com.mungcle.gateway.api
+
+import com.mungcle.gateway.dto.UpdateUserRequest
+import com.mungcle.gateway.dto.UserDetailResponse
+import com.mungcle.gateway.dto.UserResponse
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.grpc.PetProfileClient
+import com.mungcle.gateway.infrastructure.security.AuthUser
+import jakarta.validation.Valid
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/users")
+class UserController(
+    private val identityClient: IdentityClient,
+    private val petProfileClient: PetProfileClient,
+) {
+
+    @GetMapping("/me")
+    fun getMe(@AuthUser userId: Long): UserDetailResponse = runBlocking {
+        val userDeferred = async { identityClient.getUser(userId) }
+        val dogsDeferred = async { petProfileClient.getDogsByOwner(userId) }
+        val user = userDeferred.await()
+        val dogs = dogsDeferred.await()
+        UserDetailResponse(
+            id = user.id,
+            nickname = user.nickname,
+            neighborhood = user.neighborhood,
+            profilePhotoUrl = user.profilePhotoUrl,
+            dogCount = dogs.size,
+        )
+    }
+
+    @PatchMapping("/me")
+    fun updateMe(
+        @AuthUser userId: Long,
+        @Valid @RequestBody req: UpdateUserRequest,
+    ): UserResponse = runBlocking {
+        val user = identityClient.updateUser(
+            userId = userId,
+            nickname = req.nickname,
+            neighborhood = req.neighborhood,
+            profilePhotoPath = req.profilePhotoPath,
+        )
+        UserResponse(
+            id = user.id,
+            nickname = user.nickname,
+            neighborhood = user.neighborhood,
+            profilePhotoUrl = user.profilePhotoUrl,
+        )
+    }
+
+    @DeleteMapping("/me")
+    fun deleteMe(@AuthUser userId: Long): Unit = runBlocking {
+        identityClient.deleteUser(userId)
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/config/SecurityConfig.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/config/SecurityConfig.kt
@@ -1,0 +1,35 @@
+package com.mungcle.gateway.config
+
+import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(private val jwtFilter: JwtAuthenticationFilter) {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests {
+                it.requestMatchers("/api/auth/**", "/api/health", "/actuator/**").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .exceptionHandling {
+                it.authenticationEntryPoint { _, response, _ ->
+                    response.status = 401
+                    response.contentType = "application/json"
+                    response.writer.write("""{"statusCode":401,"code":"AUTH_TOKEN_INVALID","message":"인증이 필요합니다"}""")
+                }
+            }
+        return http.build()
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/config/WebConfig.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/config/WebConfig.kt
@@ -1,0 +1,25 @@
+package com.mungcle.gateway.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(
+    private val authUserArgumentResolver: AuthUserArgumentResolver,
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(authUserArgumentResolver)
+    }
+
+    override fun configureMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
+        val objectMapper = ObjectMapper().registerKotlinModule()
+        converters.add(MappingJackson2HttpMessageConverter(objectMapper))
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/dto/AuthDtos.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/dto/AuthDtos.kt
@@ -1,0 +1,50 @@
+package com.mungcle.gateway.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class KakaoLoginRequest(
+    @field:NotBlank val kakaoAccessToken: String,
+)
+
+data class RegisterRequest(
+    @field:Email @field:NotBlank val email: String,
+    @field:Size(min = 8) val password: String,
+    @field:NotBlank @field:Size(max = 20) val nickname: String,
+)
+
+data class LoginRequest(
+    @field:NotBlank val email: String,
+    @field:NotBlank val password: String,
+)
+
+data class PushTokenRequest(
+    @field:NotBlank val pushToken: String,
+)
+
+data class AuthResponseDto(
+    val accessToken: String,
+    val user: UserResponse,
+)
+
+data class UserResponse(
+    val id: Long,
+    val nickname: String,
+    val neighborhood: String,
+    val profilePhotoUrl: String,
+)
+
+data class UserDetailResponse(
+    val id: Long,
+    val nickname: String,
+    val neighborhood: String,
+    val profilePhotoUrl: String,
+    val dogCount: Int,
+)
+
+data class UpdateUserRequest(
+    val nickname: String?,
+    val neighborhood: String?,
+    val profilePhotoPath: String?,
+)

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/dto/BlockDtos.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/dto/BlockDtos.kt
@@ -1,0 +1,13 @@
+package com.mungcle.gateway.dto
+
+import jakarta.validation.constraints.NotNull
+
+data class CreateBlockRequest(
+    @field:NotNull val blockedUserId: Long,
+)
+
+data class BlockResponse(
+    val blockedUserId: Long,
+    val blockedNickname: String,
+    val createdAt: Long,
+)

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/dto/DogDtos.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/dto/DogDtos.kt
@@ -1,0 +1,38 @@
+package com.mungcle.gateway.dto
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class CreateDogRequest(
+    @field:NotBlank val name: String,
+    @field:NotBlank val breed: String,
+    @field:NotNull val size: String,
+    val temperaments: List<String> = emptyList(),
+    @field:Min(1) @field:Max(5) val sociability: Int,
+    val photoPath: String? = null,
+    val vaccinationPhotoPath: String? = null,
+)
+
+data class UpdateDogRequest(
+    val name: String? = null,
+    val breed: String? = null,
+    val size: String? = null,
+    val temperaments: List<String>? = null,
+    @field:Min(1) @field:Max(5) val sociability: Int? = null,
+    val photoPath: String? = null,
+    val vaccinationPhotoPath: String? = null,
+)
+
+data class DogResponse(
+    val id: Long,
+    val ownerId: Long,
+    val name: String,
+    val breed: String,
+    val size: String,
+    val temperaments: List<String>,
+    val sociability: Int,
+    val photoUrl: String,
+    val vaccinationRegistered: Boolean,
+)

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/dto/ReportDtos.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/dto/ReportDtos.kt
@@ -1,0 +1,9 @@
+package com.mungcle.gateway.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+data class CreateReportRequest(
+    @field:NotNull val reportedUserId: Long,
+    @field:NotBlank val reason: String,
+)

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/exception/GlobalExceptionHandler.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,36 @@
+package com.mungcle.gateway.infrastructure.exception
+
+import com.mungcle.gateway.infrastructure.grpc.GrpcStatusConverter
+import io.grpc.StatusException
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(StatusException::class)
+    fun handleGrpcStatus(e: StatusException): ResponseEntity<ErrorResponse> {
+        val httpStatus = GrpcStatusConverter.toHttpStatus(e.status.code)
+        val code = e.status.description?.substringBefore(" ") ?: e.status.code.name
+        return ResponseEntity.status(httpStatus).body(
+            ErrorResponse(httpStatus.value(), code, e.status.description ?: "")
+        )
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidation(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val fieldErrors = e.bindingResult.fieldErrors
+            .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
+        return ResponseEntity.badRequest().body(
+            ErrorResponse(400, "VALIDATION_ERROR", fieldErrors)
+        )
+    }
+}
+
+data class ErrorResponse(
+    val statusCode: Int,
+    val code: String,
+    val message: String,
+)

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/grpc/GrpcStatusConverter.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/grpc/GrpcStatusConverter.kt
@@ -1,0 +1,18 @@
+package com.mungcle.gateway.infrastructure.grpc
+
+import io.grpc.Status
+import org.springframework.http.HttpStatus
+
+object GrpcStatusConverter {
+
+    fun toHttpStatus(grpcStatus: Status.Code): HttpStatus = when (grpcStatus) {
+        Status.Code.NOT_FOUND -> HttpStatus.NOT_FOUND
+        Status.Code.ALREADY_EXISTS -> HttpStatus.CONFLICT
+        Status.Code.PERMISSION_DENIED -> HttpStatus.FORBIDDEN
+        Status.Code.INVALID_ARGUMENT -> HttpStatus.BAD_REQUEST
+        Status.Code.FAILED_PRECONDITION -> HttpStatus.GONE
+        Status.Code.UNAUTHENTICATED -> HttpStatus.UNAUTHORIZED
+        Status.Code.RESOURCE_EXHAUSTED -> HttpStatus.TOO_MANY_REQUESTS
+        else -> HttpStatus.INTERNAL_SERVER_ERROR
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/grpc/IdentityClient.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/grpc/IdentityClient.kt
@@ -1,0 +1,108 @@
+package com.mungcle.gateway.infrastructure.grpc
+
+import com.mungcle.proto.identity.v1.AuthResponse
+import com.mungcle.proto.identity.v1.IdentityServiceGrpcKt
+import com.mungcle.proto.identity.v1.ListBlocksResponse
+import com.mungcle.proto.identity.v1.UserInfo
+import com.mungcle.proto.identity.v1.ValidateTokenResponse
+import com.mungcle.proto.identity.v1.authenticateKakaoRequest
+import com.mungcle.proto.identity.v1.createBlockRequest
+import com.mungcle.proto.identity.v1.createReportRequest
+import com.mungcle.proto.identity.v1.deleteBlockRequest
+import com.mungcle.proto.identity.v1.deleteUserRequest
+import com.mungcle.proto.identity.v1.getUserRequest
+import com.mungcle.proto.identity.v1.listBlocksRequest
+import com.mungcle.proto.identity.v1.loginEmailRequest
+import com.mungcle.proto.identity.v1.registerEmailRequest
+import com.mungcle.proto.identity.v1.updatePushTokenRequest
+import com.mungcle.proto.identity.v1.updateUserRequest
+import com.mungcle.proto.identity.v1.validateTokenRequest
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.springframework.stereotype.Component
+
+@Component
+class IdentityClient(
+    @GrpcClient("identity") private val stub: IdentityServiceGrpcKt.IdentityServiceCoroutineStub,
+) {
+
+    suspend fun authenticateKakao(kakaoAccessToken: String): AuthResponse =
+        stub.authenticateKakao(authenticateKakaoRequest {
+            this.kakaoAccessToken = kakaoAccessToken
+        })
+
+    suspend fun registerEmail(email: String, password: String, nickname: String): AuthResponse =
+        stub.registerEmail(registerEmailRequest {
+            this.email = email
+            this.password = password
+            this.nickname = nickname
+        })
+
+    suspend fun loginEmail(email: String, password: String): AuthResponse =
+        stub.loginEmail(loginEmailRequest {
+            this.email = email
+            this.password = password
+        })
+
+    suspend fun validateToken(accessToken: String): ValidateTokenResponse =
+        stub.validateToken(validateTokenRequest {
+            this.accessToken = accessToken
+        })
+
+    suspend fun updatePushToken(userId: Long, pushToken: String) {
+        stub.updatePushToken(updatePushTokenRequest {
+            this.userId = userId
+            this.pushToken = pushToken
+        })
+    }
+
+    suspend fun getUser(userId: Long): UserInfo =
+        stub.getUser(getUserRequest {
+            this.userId = userId
+        })
+
+    suspend fun updateUser(
+        userId: Long,
+        nickname: String? = null,
+        neighborhood: String? = null,
+        profilePhotoPath: String? = null,
+    ): UserInfo =
+        stub.updateUser(updateUserRequest {
+            this.userId = userId
+            if (nickname != null) this.nickname = nickname
+            if (neighborhood != null) this.neighborhood = neighborhood
+            if (profilePhotoPath != null) this.profilePhotoPath = profilePhotoPath
+        })
+
+    suspend fun deleteUser(userId: Long) {
+        stub.deleteUser(deleteUserRequest {
+            this.userId = userId
+        })
+    }
+
+    suspend fun createBlock(blockerId: Long, blockedId: Long) {
+        stub.createBlock(createBlockRequest {
+            this.blockerId = blockerId
+            this.blockedId = blockedId
+        })
+    }
+
+    suspend fun deleteBlock(blockerId: Long, blockedId: Long) {
+        stub.deleteBlock(deleteBlockRequest {
+            this.blockerId = blockerId
+            this.blockedId = blockedId
+        })
+    }
+
+    suspend fun listBlocks(userId: Long): ListBlocksResponse =
+        stub.listBlocks(listBlocksRequest {
+            this.userId = userId
+        })
+
+    suspend fun createReport(reporterId: Long, reportedId: Long, reason: String) {
+        stub.createReport(createReportRequest {
+            this.reporterId = reporterId
+            this.reportedId = reportedId
+            this.reason = reason
+        })
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/grpc/PetProfileClient.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/grpc/PetProfileClient.kt
@@ -1,0 +1,79 @@
+package com.mungcle.gateway.infrastructure.grpc
+
+import com.mungcle.proto.petprofile.v1.DogInfo
+import com.mungcle.proto.petprofile.v1.DogSize
+import com.mungcle.proto.petprofile.v1.PetProfileServiceGrpcKt
+import com.mungcle.proto.petprofile.v1.createDogRequest
+import com.mungcle.proto.petprofile.v1.deleteDogRequest
+import com.mungcle.proto.petprofile.v1.getDogRequest
+import com.mungcle.proto.petprofile.v1.getDogsByOwnerRequest
+import com.mungcle.proto.petprofile.v1.updateDogRequest
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.springframework.stereotype.Component
+
+@Component
+class PetProfileClient(
+    @GrpcClient("pet-profile") private val stub: PetProfileServiceGrpcKt.PetProfileServiceCoroutineStub,
+) {
+
+    suspend fun createDog(
+        ownerId: Long,
+        dogName: String,
+        dogBreed: String,
+        dogSize: DogSize,
+        dogTemperaments: List<String>,
+        dogSociability: Int,
+        photoPath: String? = null,
+        vaccinationPhotoPath: String? = null,
+    ): DogInfo =
+        stub.createDog(createDogRequest {
+            this.ownerId = ownerId
+            this.name = dogName
+            this.breed = dogBreed
+            this.size = dogSize
+            this.temperaments += dogTemperaments
+            this.sociability = dogSociability
+            if (photoPath != null) this.photoPath = photoPath
+            if (vaccinationPhotoPath != null) this.vaccinationPhotoPath = vaccinationPhotoPath
+        })
+
+    suspend fun getDog(dogId: Long): DogInfo =
+        stub.getDog(getDogRequest {
+            this.dogId = dogId
+        })
+
+    suspend fun getDogsByOwner(ownerId: Long): List<DogInfo> =
+        stub.getDogsByOwner(getDogsByOwnerRequest {
+            this.ownerId = ownerId
+        }).dogsList
+
+    suspend fun updateDog(
+        dogId: Long,
+        requesterId: Long,
+        dogName: String? = null,
+        dogBreed: String? = null,
+        dogSize: DogSize? = null,
+        dogTemperaments: List<String>? = null,
+        dogSociability: Int? = null,
+        photoPath: String? = null,
+        vaccinationPhotoPath: String? = null,
+    ): DogInfo =
+        stub.updateDog(updateDogRequest {
+            this.dogId = dogId
+            this.requesterId = requesterId
+            if (dogName != null) this.name = dogName
+            if (dogBreed != null) this.breed = dogBreed
+            if (dogSize != null) this.size = dogSize
+            if (dogTemperaments != null) this.temperaments += dogTemperaments
+            if (dogSociability != null) this.sociability = dogSociability
+            if (photoPath != null) this.photoPath = photoPath
+            if (vaccinationPhotoPath != null) this.vaccinationPhotoPath = vaccinationPhotoPath
+        })
+
+    suspend fun deleteDog(dogId: Long, ownerId: Long) {
+        stub.deleteDog(deleteDogRequest {
+            this.dogId = dogId
+            this.requesterId = ownerId
+        })
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/security/AuthUser.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/security/AuthUser.kt
@@ -1,0 +1,32 @@
+package com.mungcle.gateway.infrastructure.security
+
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import org.springframework.web.server.ResponseStatusException
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AuthUser
+
+@Component
+class AuthUserArgumentResolver : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(AuthUser::class.java) && parameter.parameterType == Long::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Long {
+        val auth = SecurityContextHolder.getContext().authentication
+        return auth?.principal as? Long ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED)
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/security/JwtAuthenticationFilter.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/security/JwtAuthenticationFilter.kt
@@ -1,0 +1,43 @@
+package com.mungcle.gateway.infrastructure.security
+
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.proto.identity.v1.ValidateTokenResponse
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kotlinx.coroutines.runBlocking
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val identityClient: IdentityClient,
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val token = extractToken(request)
+        if (token != null) {
+            try {
+                val validateResponse: ValidateTokenResponse = runBlocking { identityClient.validateToken(token) }
+                if (validateResponse.valid) {
+                    val auth = UsernamePasswordAuthenticationToken(validateResponse.userId, null, emptyList())
+                    SecurityContextHolder.getContext().authentication = auth
+                }
+            } catch (e: Exception) {
+                // 인증 실패 — SecurityContext 비우고 계속
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun extractToken(request: HttpServletRequest): String? {
+        val header = request.getHeader("Authorization") ?: return null
+        return if (header.startsWith("Bearer ")) header.substring(7) else null
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/AuthControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/AuthControllerTest.kt
@@ -1,0 +1,100 @@
+package com.mungcle.gateway.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.mungcle.gateway.config.SecurityConfig
+import com.mungcle.gateway.config.WebConfig
+import com.mungcle.gateway.dto.LoginRequest
+import com.mungcle.gateway.dto.RegisterRequest
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
+import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
+import com.mungcle.proto.identity.v1.authResponse
+import com.mungcle.proto.identity.v1.userInfo
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(AuthController::class)
+@Import(SecurityConfig::class, WebConfig::class, JwtAuthenticationFilter::class, AuthUserArgumentResolver::class)
+class AuthControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var identityClient: IdentityClient
+
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    private val fakeAuthResponse = authResponse {
+        accessToken = "test-jwt-token"
+        user = userInfo {
+            id = 1L
+            nickname = "testuser"
+            neighborhood = "강남구"
+            profilePhotoUrl = ""
+        }
+    }
+
+    @Test
+    fun `이메일 회원가입 성공 — 200 반환`() {
+        val req = RegisterRequest(email = "test@example.com", password = "password123", nickname = "testuser")
+        coEvery { identityClient.registerEmail(any(), any(), any()) } returns fakeAuthResponse
+
+        mockMvc.perform(
+            post("/api/auth/email/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.accessToken").value("test-jwt-token"))
+            .andExpect(jsonPath("$.user.nickname").value("testuser"))
+    }
+
+    @Test
+    fun `이메일 로그인 성공 — 200 반환`() {
+        val req = LoginRequest(email = "test@example.com", password = "password123")
+        coEvery { identityClient.loginEmail(any(), any()) } returns fakeAuthResponse
+
+        mockMvc.perform(
+            post("/api/auth/email/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.accessToken").value("test-jwt-token"))
+    }
+
+    @Test
+    fun `이메일 형식 오류 — 400 반환`() {
+        val req = mapOf("email" to "not-an-email", "password" to "password123", "nickname" to "testuser")
+
+        mockMvc.perform(
+            post("/api/auth/email/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `비밀번호 8자 미만 — 400 반환`() {
+        val req = mapOf("email" to "test@example.com", "password" to "short", "nickname" to "testuser")
+
+        mockMvc.perform(
+            post("/api/auth/email/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+        )
+            .andExpect(status().isBadRequest)
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/BlockControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/BlockControllerTest.kt
@@ -1,0 +1,102 @@
+package com.mungcle.gateway.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.mungcle.gateway.config.SecurityConfig
+import com.mungcle.gateway.config.WebConfig
+import com.mungcle.gateway.dto.CreateBlockRequest
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
+import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
+import com.mungcle.proto.identity.v1.blockInfo
+import com.mungcle.proto.identity.v1.listBlocksResponse
+import com.mungcle.proto.identity.v1.validateTokenResponse
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(BlockController::class)
+@Import(SecurityConfig::class, WebConfig::class, JwtAuthenticationFilter::class, AuthUserArgumentResolver::class)
+class BlockControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var identityClient: IdentityClient
+
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    private fun setupAuth(userId: Long = 1L) {
+        val tokenResponse = validateTokenResponse {
+            this.userId = userId
+            valid = true
+        }
+        coEvery { identityClient.validateToken(any()) } returns tokenResponse
+    }
+
+    @Test
+    fun `차단 생성 성공 — 201 반환`() {
+        setupAuth()
+        coJustRun { identityClient.createBlock(any(), any()) }
+        val req = CreateBlockRequest(blockedUserId = 99L)
+
+        mockMvc.perform(
+            post("/api/blocks")
+                .header("Authorization", "Bearer valid-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+        )
+            .andExpect(status().isCreated)
+    }
+
+    @Test
+    fun `차단 목록 조회 성공 — 200 반환`() {
+        setupAuth()
+        val response = listBlocksResponse {
+            blocks += blockInfo {
+                blockedUserId = 99L
+                blockedNickname = "blocked_user"
+                createdAt = 1000L
+            }
+        }
+        coEvery { identityClient.listBlocks(1L) } returns response
+
+        mockMvc.perform(
+            get("/api/blocks")
+                .header("Authorization", "Bearer valid-token")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].blockedUserId").value(99))
+            .andExpect(jsonPath("$[0].blockedNickname").value("blocked_user"))
+    }
+
+    @Test
+    fun `차단 해제 성공 — 204 반환`() {
+        setupAuth()
+        coJustRun { identityClient.deleteBlock(any(), any()) }
+
+        mockMvc.perform(
+            delete("/api/blocks/99")
+                .header("Authorization", "Bearer valid-token")
+        )
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `비인증 차단 목록 조회 — 401 반환`() {
+        mockMvc.perform(get("/api/blocks"))
+            .andExpect(status().isUnauthorized)
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/DogControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/DogControllerTest.kt
@@ -1,0 +1,99 @@
+package com.mungcle.gateway.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.mungcle.gateway.config.SecurityConfig
+import com.mungcle.gateway.config.WebConfig
+import com.mungcle.gateway.dto.CreateDogRequest
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.grpc.PetProfileClient
+import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
+import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
+import com.mungcle.proto.identity.v1.validateTokenResponse
+import com.mungcle.proto.petprofile.v1.DogSize
+import com.mungcle.proto.petprofile.v1.dogInfo
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(DogController::class)
+@Import(SecurityConfig::class, WebConfig::class, JwtAuthenticationFilter::class, AuthUserArgumentResolver::class)
+class DogControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    private lateinit var petProfileClient: PetProfileClient
+
+    @MockkBean
+    private lateinit var identityClient: IdentityClient
+
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    private val fakeDog = dogInfo {
+        id = 1L
+        ownerId = 10L
+        name = "초코"
+        breed = "골든리트리버"
+        size = DogSize.DOG_SIZE_LARGE
+        temperaments += listOf("FRIENDLY")
+        sociability = 4
+        photoUrl = ""
+        vaccinationRegistered = false
+    }
+
+    private fun setupAuth(userId: Long = 10L) {
+        val tokenResponse = validateTokenResponse {
+            this.userId = userId
+            valid = true
+        }
+        coEvery { identityClient.validateToken(any()) } returns tokenResponse
+    }
+
+    @Test
+    fun `반려견 등록 성공 — 201 반환`() {
+        setupAuth()
+        val req = CreateDogRequest(name = "초코", breed = "골든리트리버", size = "LARGE", sociability = 4)
+        coEvery { petProfileClient.createDog(any(), any(), any(), any(), any(), any(), null, null) } returns fakeDog
+
+        mockMvc.perform(
+            post("/api/dogs")
+                .header("Authorization", "Bearer valid-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.name").value("초코"))
+    }
+
+    @Test
+    fun `반려견 목록 조회 성공 — 200 반환`() {
+        setupAuth()
+        coEvery { petProfileClient.getDogsByOwner(10L) } returns listOf(fakeDog)
+
+        mockMvc.perform(
+            get("/api/dogs")
+                .header("Authorization", "Bearer valid-token")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].name").value("초코"))
+    }
+
+    @Test
+    fun `비인증 접근 — 401 반환`() {
+        mockMvc.perform(
+            get("/api/dogs")
+        )
+            .andExpect(status().isUnauthorized)
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/infrastructure/grpc/GrpcStatusConverterTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/infrastructure/grpc/GrpcStatusConverterTest.kt
@@ -1,0 +1,54 @@
+package com.mungcle.gateway.infrastructure.grpc
+
+import io.grpc.Status
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class GrpcStatusConverterTest {
+
+    @Test
+    fun `NOT_FOUND는 404로 변환`() {
+        assertEquals(HttpStatus.NOT_FOUND, GrpcStatusConverter.toHttpStatus(Status.Code.NOT_FOUND))
+    }
+
+    @Test
+    fun `ALREADY_EXISTS는 409로 변환`() {
+        assertEquals(HttpStatus.CONFLICT, GrpcStatusConverter.toHttpStatus(Status.Code.ALREADY_EXISTS))
+    }
+
+    @Test
+    fun `PERMISSION_DENIED는 403으로 변환`() {
+        assertEquals(HttpStatus.FORBIDDEN, GrpcStatusConverter.toHttpStatus(Status.Code.PERMISSION_DENIED))
+    }
+
+    @Test
+    fun `INVALID_ARGUMENT는 400으로 변환`() {
+        assertEquals(HttpStatus.BAD_REQUEST, GrpcStatusConverter.toHttpStatus(Status.Code.INVALID_ARGUMENT))
+    }
+
+    @Test
+    fun `FAILED_PRECONDITION은 410으로 변환`() {
+        assertEquals(HttpStatus.GONE, GrpcStatusConverter.toHttpStatus(Status.Code.FAILED_PRECONDITION))
+    }
+
+    @Test
+    fun `UNAUTHENTICATED는 401로 변환`() {
+        assertEquals(HttpStatus.UNAUTHORIZED, GrpcStatusConverter.toHttpStatus(Status.Code.UNAUTHENTICATED))
+    }
+
+    @Test
+    fun `RESOURCE_EXHAUSTED는 429로 변환`() {
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS, GrpcStatusConverter.toHttpStatus(Status.Code.RESOURCE_EXHAUSTED))
+    }
+
+    @Test
+    fun `INTERNAL은 500으로 변환`() {
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, GrpcStatusConverter.toHttpStatus(Status.Code.INTERNAL))
+    }
+
+    @Test
+    fun `UNKNOWN은 500으로 변환`() {
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, GrpcStatusConverter.toHttpStatus(Status.Code.UNKNOWN))
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/infrastructure/security/JwtAuthenticationFilterTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/infrastructure/security/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,93 @@
+package com.mungcle.gateway.infrastructure.security
+
+import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.proto.identity.v1.validateTokenResponse
+import io.grpc.Status
+import io.grpc.StatusException
+import io.mockk.coEvery
+import io.mockk.mockk
+import jakarta.servlet.FilterChain
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+
+class JwtAuthenticationFilterTest {
+
+    private val identityClient: IdentityClient = mockk()
+    private val filter = JwtAuthenticationFilter(identityClient)
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `유효한 토큰 — SecurityContext에 인증 설정`() {
+        val validResponse = validateTokenResponse {
+            userId = 42L
+            valid = true
+        }
+        coEvery { identityClient.validateToken("valid-token") } returns validResponse
+
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "Bearer valid-token")
+        }
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        val auth = SecurityContextHolder.getContext().authentication
+        assertEquals(42L, auth?.principal)
+    }
+
+    @Test
+    fun `토큰 없음 — SecurityContext 비어있음`() {
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+    }
+
+    @Test
+    fun `만료된 토큰 — SecurityContext 비어있음`() {
+        coEvery { identityClient.validateToken("expired-token") } throws StatusException(Status.UNAUTHENTICATED)
+
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "Bearer expired-token")
+        }
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+    }
+
+    @Test
+    fun `유효하지 않은 토큰 응답 — SecurityContext 비어있음`() {
+        val invalidResponse = validateTokenResponse {
+            userId = 0L
+            valid = false
+        }
+        coEvery { identityClient.validateToken("invalid-token") } returns invalidResponse
+
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "Bearer invalid-token")
+        }
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+
+        filter.doFilter(request, response, chain)
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+    }
+}

--- a/services/api-gateway/src/test/resources/application-test.yml
+++ b/services/api-gateway/src/test/resources/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  application:
+    name: api-gateway-test
+
+grpc:
+  client:
+    identity:
+      address: static://localhost:50051
+      negotiation-type: plaintext
+    pet-profile:
+      address: static://localhost:50052
+      negotiation-type: plaintext

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,7 @@ include("common:kafka-common")
 include("common:grpc-client")
 
 // Services
+include("services:api-gateway")
 include("services:pet-profile")
 include("services:walks")
 include("services:social")


### PR DESCRIPTION
## Summary
- JWT 인증 필터 (identity gRPC 위임), SecurityConfig, @AuthUser 어노테이션
- IdentityClient, PetProfileClient gRPC 래퍼
- gRPC StatusException → HTTP 표준 에러 변환 (GlobalExceptionHandler)
- REST 컨트롤러: Auth (카카오/이메일), Users (BFF 병렬 조합), Dogs CRUD, Blocks, Reports
- DTO + Bean Validation
- 24개 테스트 통과 (MockMvc + MockK)

## Task Reference
- plan-docs/tasks/09-gateway-auth-dogs.md

## Test plan
- [x] `./gradlew :services:api-gateway:clean :services:api-gateway:test` 통과
- [ ] JWT 인증 (유효/만료/없음)
- [ ] Auth 가입/로그인 플로우
- [ ] Dogs CRUD + 비인증 401
- [ ] Blocks CRUD + 비인증 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>