### PR TITLE
MC-46: api-gateway Circuit Breaker — Resilience4j

### DIFF
--- a/services/api-gateway/build.gradle.kts
+++ b/services/api-gateway/build.gradle.kts
@@ -27,6 +27,11 @@ dependencies {
     implementation("io.grpc:grpc-protobuf:${property("grpcVersion")}")
     implementation("com.google.protobuf:protobuf-kotlin:${property("protobufVersion")}")
 
+    // Resilience4j Circuit Breaker
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
+    implementation("io.github.resilience4j:resilience4j-reactor:2.2.0")
+    implementation("io.github.resilience4j:resilience4j-kotlin:2.2.0")
+
     // Kotlin Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.10.1")
@@ -40,6 +45,7 @@ dependencies {
 
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("io.mockk:mockk:${property("mockkVersion")}")

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/AuthController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/AuthController.kt
@@ -8,6 +8,7 @@ import com.mungcle.gateway.dto.RegisterRequest
 import com.mungcle.gateway.dto.SocialLoginRequest
 import com.mungcle.gateway.dto.UserResponse
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import com.mungcle.proto.identity.v1.AuthResponse
 import jakarta.validation.Valid
@@ -18,29 +19,32 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/auth")
-class AuthController(private val identityClient: IdentityClient) {
+class AuthController(
+    private val identityClient: IdentityClient,
+    private val cb: CircuitBreakerWrapper,
+) {
 
     // 기존 카카오 엔드포인트 유지 (하위 호환)
     @PostMapping("/kakao")
     suspend fun kakaoLogin(@Valid @RequestBody req: KakaoLoginRequest): AuthResponseDto =
-        identityClient.authenticateSocial("KAKAO", req.kakaoAccessToken).toDto()
+        cb.execute("identity-service") { identityClient.authenticateSocial("KAKAO", req.kakaoAccessToken) }.toDto()
 
     // 범용 소셜 로그인 엔드포인트
     @PostMapping("/social")
     suspend fun socialLogin(@Valid @RequestBody req: SocialLoginRequest): AuthResponseDto =
-        identityClient.authenticateSocial(req.provider, req.accessToken).toDto()
+        cb.execute("identity-service") { identityClient.authenticateSocial(req.provider, req.accessToken) }.toDto()
 
     @PostMapping("/email/register")
     suspend fun register(@Valid @RequestBody req: RegisterRequest): AuthResponseDto =
-        identityClient.registerEmail(req.email, req.password, req.nickname).toDto()
+        cb.execute("identity-service") { identityClient.registerEmail(req.email, req.password, req.nickname) }.toDto()
 
     @PostMapping("/email/login")
     suspend fun login(@Valid @RequestBody req: LoginRequest): AuthResponseDto =
-        identityClient.loginEmail(req.email, req.password).toDto()
+        cb.execute("identity-service") { identityClient.loginEmail(req.email, req.password) }.toDto()
 
     @PostMapping("/push-token")
     suspend fun updatePushToken(@AuthUser userId: Long, @Valid @RequestBody req: PushTokenRequest) {
-        identityClient.updatePushToken(userId, req.pushToken)
+        cb.execute("identity-service") { identityClient.updatePushToken(userId, req.pushToken) }
     }
 
     private fun AuthResponse.toDto() = AuthResponseDto(

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/BlockController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/BlockController.kt
@@ -3,6 +3,7 @@ package com.mungcle.gateway.api
 import com.mungcle.gateway.dto.BlockResponse
 import com.mungcle.gateway.dto.CreateBlockRequest
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -17,23 +18,26 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/blocks")
-class BlockController(private val identityClient: IdentityClient) {
+class BlockController(
+    private val identityClient: IdentityClient,
+    private val cb: CircuitBreakerWrapper,
+) {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     suspend fun createBlock(@AuthUser userId: Long, @Valid @RequestBody req: CreateBlockRequest) {
-        identityClient.createBlock(blockerId = userId, blockedId = req.blockedUserId)
+        cb.execute("identity-service") { identityClient.createBlock(blockerId = userId, blockedId = req.blockedUserId) }
     }
 
     @DeleteMapping("/{blockedUserId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     suspend fun deleteBlock(@AuthUser userId: Long, @PathVariable blockedUserId: Long) {
-        identityClient.deleteBlock(blockerId = userId, blockedId = blockedUserId)
+        cb.execute("identity-service") { identityClient.deleteBlock(blockerId = userId, blockedId = blockedUserId) }
     }
 
     @GetMapping
     suspend fun listBlocks(@AuthUser userId: Long): List<BlockResponse> =
-        identityClient.listBlocks(userId).blocksList.map { block ->
+        cb.execute("identity-service") { identityClient.listBlocks(userId) }.blocksList.map { block ->
             BlockResponse(
                 blockedUserId = block.blockedUserId,
                 blockedNickname = block.blockedNickname,

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/DogController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/DogController.kt
@@ -4,6 +4,7 @@ import com.mungcle.gateway.dto.CreateDogRequest
 import com.mungcle.gateway.dto.DogResponse
 import com.mungcle.gateway.dto.UpdateDogRequest
 import com.mungcle.gateway.infrastructure.grpc.PetProfileClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import com.mungcle.proto.petprofile.v1.DogInfo
 import com.mungcle.proto.petprofile.v1.DogSize
@@ -21,29 +22,34 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/dogs")
-class DogController(private val petProfileClient: PetProfileClient) {
+class DogController(
+    private val petProfileClient: PetProfileClient,
+    private val cb: CircuitBreakerWrapper,
+) {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     suspend fun createDog(@AuthUser userId: Long, @Valid @RequestBody req: CreateDogRequest): DogResponse =
-        petProfileClient.createDog(
-            ownerId = userId,
-            dogName = req.name,
-            dogBreed = req.breed,
-            dogSize = parseDogSize(req.size),
-            dogTemperaments = req.temperaments,
-            dogSociability = req.sociability,
-            photoPath = req.photoPath,
-            vaccinationPhotoPath = req.vaccinationPhotoPath,
-        ).toResponse()
+        cb.execute("pet-profile-service") {
+            petProfileClient.createDog(
+                ownerId = userId,
+                dogName = req.name,
+                dogBreed = req.breed,
+                dogSize = parseDogSize(req.size),
+                dogTemperaments = req.temperaments,
+                dogSociability = req.sociability,
+                photoPath = req.photoPath,
+                vaccinationPhotoPath = req.vaccinationPhotoPath,
+            )
+        }.toResponse()
 
     @GetMapping
     suspend fun getDogs(@AuthUser userId: Long): List<DogResponse> =
-        petProfileClient.getDogsByOwner(userId).map { it.toResponse() }
+        cb.execute("pet-profile-service") { petProfileClient.getDogsByOwner(userId) }.map { it.toResponse() }
 
     @GetMapping("/{id}")
     suspend fun getDog(@AuthUser userId: Long, @PathVariable id: Long): DogResponse =
-        petProfileClient.getDog(id).toResponse()
+        cb.execute("pet-profile-service") { petProfileClient.getDog(id) }.toResponse()
 
     @PatchMapping("/{id}")
     suspend fun updateDog(
@@ -51,22 +57,24 @@ class DogController(private val petProfileClient: PetProfileClient) {
         @PathVariable id: Long,
         @Valid @RequestBody req: UpdateDogRequest,
     ): DogResponse =
-        petProfileClient.updateDog(
-            dogId = id,
-            requesterId = userId,
-            dogName = req.name,
-            dogBreed = req.breed,
-            dogSize = req.size?.let { parseDogSize(it) },
-            dogTemperaments = req.temperaments,
-            dogSociability = req.sociability,
-            photoPath = req.photoPath,
-            vaccinationPhotoPath = req.vaccinationPhotoPath,
-        ).toResponse()
+        cb.execute("pet-profile-service") {
+            petProfileClient.updateDog(
+                dogId = id,
+                requesterId = userId,
+                dogName = req.name,
+                dogBreed = req.breed,
+                dogSize = req.size?.let { parseDogSize(it) },
+                dogTemperaments = req.temperaments,
+                dogSociability = req.sociability,
+                photoPath = req.photoPath,
+                vaccinationPhotoPath = req.vaccinationPhotoPath,
+            )
+        }.toResponse()
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     suspend fun deleteDog(@AuthUser userId: Long, @PathVariable id: Long) {
-        petProfileClient.deleteDog(dogId = id, ownerId = userId)
+        cb.execute("pet-profile-service") { petProfileClient.deleteDog(dogId = id, ownerId = userId) }
     }
 
     private fun parseDogSize(size: String): DogSize = when (size.uppercase()) {

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/GreetingController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/GreetingController.kt
@@ -6,6 +6,7 @@ import com.mungcle.gateway.dto.MessageResponse
 import com.mungcle.gateway.dto.RespondGreetingRequest
 import com.mungcle.gateway.dto.SendMessageRequest
 import com.mungcle.gateway.infrastructure.grpc.SocialClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import com.mungcle.proto.social.v1.GreetingDirection
 import com.mungcle.proto.social.v1.GreetingInfo
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/greetings")
 class GreetingController(
     private val socialClient: SocialClient,
+    private val cb: CircuitBreakerWrapper,
 ) {
 
     @PostMapping
@@ -34,11 +36,13 @@ class GreetingController(
         @AuthUser userId: Long,
         @Valid @RequestBody req: CreateGreetingRequest,
     ): GreetingResponse =
-        socialClient.createGreeting(
-            senderUserId = userId,
-            senderDogId = req.senderDogId,
-            receiverWalkId = req.receiverWalkId,
-        ).toResponse()
+        cb.execute("social-service") {
+            socialClient.createGreeting(
+                senderUserId = userId,
+                senderDogId = req.senderDogId,
+                receiverWalkId = req.receiverWalkId,
+            )
+        }.toResponse()
 
     @PostMapping("/{id}/respond")
     suspend fun respondGreeting(
@@ -46,15 +50,17 @@ class GreetingController(
         @PathVariable id: Long,
         @Valid @RequestBody req: RespondGreetingRequest,
     ): GreetingResponse =
-        socialClient.respondGreeting(
-            greetingId = id,
-            responderUserId = userId,
-            accept = req.accept,
-        ).toResponse()
+        cb.execute("social-service") {
+            socialClient.respondGreeting(
+                greetingId = id,
+                responderUserId = userId,
+                accept = req.accept,
+            )
+        }.toResponse()
 
     @GetMapping("/{id}")
     suspend fun getGreeting(@AuthUser userId: Long, @PathVariable id: Long): GreetingResponse =
-        socialClient.getGreeting(greetingId = id, userId = userId).toResponse()
+        cb.execute("social-service") { socialClient.getGreeting(greetingId = id, userId = userId) }.toResponse()
 
     @GetMapping
     suspend fun listGreetings(
@@ -64,7 +70,8 @@ class GreetingController(
     ): List<GreetingResponse> {
         val statusFilter = status?.let { parseGreetingStatus(it) }
         val directionFilter = direction?.let { parseGreetingDirection(it) }
-        return socialClient.listGreetings(userId, statusFilter, directionFilter).map { it.toResponse() }
+        return cb.execute("social-service") { socialClient.listGreetings(userId, statusFilter, directionFilter) }
+            .map { it.toResponse() }
     }
 
     @PostMapping("/{id}/messages")
@@ -74,15 +81,18 @@ class GreetingController(
         @PathVariable id: Long,
         @Valid @RequestBody req: SendMessageRequest,
     ): MessageResponse =
-        socialClient.sendMessage(
-            greetingId = id,
-            senderUserId = userId,
-            body = req.body,
-        ).toMessageResponse()
+        cb.execute("social-service") {
+            socialClient.sendMessage(
+                greetingId = id,
+                senderUserId = userId,
+                body = req.body,
+            )
+        }.toMessageResponse()
 
     @GetMapping("/{id}/messages")
     suspend fun listMessages(@AuthUser userId: Long, @PathVariable id: Long): List<MessageResponse> =
-        socialClient.listMessages(greetingId = id, userId = userId).map { it.toMessageResponse() }
+        cb.execute("social-service") { socialClient.listMessages(greetingId = id, userId = userId) }
+            .map { it.toMessageResponse() }
 
     private fun parseGreetingStatus(value: String): GreetingStatus = when (value.uppercase()) {
         "PENDING" -> GreetingStatus.GREETING_STATUS_PENDING

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/NotificationController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/NotificationController.kt
@@ -3,6 +3,7 @@ package com.mungcle.gateway.api
 import com.mungcle.gateway.dto.NotificationResponse
 import com.mungcle.gateway.dto.NotificationsResponse
 import com.mungcle.gateway.infrastructure.grpc.NotificationClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,6 +19,7 @@ import org.springframework.http.HttpStatus
 @RequestMapping("/v1/notifications")
 class NotificationController(
     private val notificationClient: NotificationClient,
+    private val cb: CircuitBreakerWrapper,
 ) {
 
     private val objectMapper = jacksonObjectMapper()
@@ -28,7 +30,7 @@ class NotificationController(
         @RequestParam(required = false) cursor: Long?,
         @RequestParam(defaultValue = "20") limit: Int,
     ): NotificationsResponse {
-        val response = notificationClient.listNotifications(userId, cursor, limit)
+        val response = cb.execute("notification-service") { notificationClient.listNotifications(userId, cursor, limit) }
         return NotificationsResponse(
             notifications = response.notificationsList.map { notification ->
                 @Suppress("UNCHECKED_CAST")
@@ -49,12 +51,12 @@ class NotificationController(
     @PostMapping("/{id}/read")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     suspend fun markRead(@AuthUser userId: Long, @PathVariable id: Long) {
-        notificationClient.markRead(notificationId = id, userId = userId)
+        cb.execute("notification-service") { notificationClient.markRead(notificationId = id, userId = userId) }
     }
 
     @PostMapping("/read-all")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     suspend fun markAllRead(@AuthUser userId: Long) {
-        notificationClient.markAllRead(userId)
+        cb.execute("notification-service") { notificationClient.markAllRead(userId) }
     }
 }

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/ReportController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/ReportController.kt
@@ -2,6 +2,7 @@ package com.mungcle.gateway.api
 
 import com.mungcle.gateway.dto.CreateReportRequest
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -13,15 +14,20 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/reports")
-class ReportController(private val identityClient: IdentityClient) {
+class ReportController(
+    private val identityClient: IdentityClient,
+    private val cb: CircuitBreakerWrapper,
+) {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     suspend fun createReport(@AuthUser userId: Long, @Valid @RequestBody req: CreateReportRequest) {
-        identityClient.createReport(
-            reporterId = userId,
-            reportedId = req.reportedUserId!!, // validated non-null by @NotNull
-            reason = req.reason,
-        )
+        cb.execute("identity-service") {
+            identityClient.createReport(
+                reporterId = userId,
+                reportedId = req.reportedUserId!!, // validated non-null by @NotNull
+                reason = req.reason,
+            )
+        }
     }
 }

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/UserController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/UserController.kt
@@ -5,6 +5,7 @@ import com.mungcle.gateway.dto.UserDetailResponse
 import com.mungcle.gateway.dto.UserResponse
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
 import com.mungcle.gateway.infrastructure.grpc.PetProfileClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import jakarta.validation.Valid
 import kotlinx.coroutines.async
@@ -21,12 +22,13 @@ import org.springframework.web.bind.annotation.RestController
 class UserController(
     private val identityClient: IdentityClient,
     private val petProfileClient: PetProfileClient,
+    private val cb: CircuitBreakerWrapper,
 ) {
 
     @GetMapping("/me")
     suspend fun getMe(@AuthUser userId: Long): UserDetailResponse = coroutineScope {
-        val userDeferred = async { identityClient.getUser(userId) }
-        val dogsDeferred = async { petProfileClient.getDogsByOwner(userId) }
+        val userDeferred = async { cb.execute("identity-service") { identityClient.getUser(userId) } }
+        val dogsDeferred = async { cb.execute("pet-profile-service") { petProfileClient.getDogsByOwner(userId) } }
         val user = userDeferred.await()
         val dogs = dogsDeferred.await()
         UserDetailResponse(
@@ -43,12 +45,14 @@ class UserController(
         @AuthUser userId: Long,
         @Valid @RequestBody req: UpdateUserRequest,
     ): UserResponse {
-        val user = identityClient.updateUser(
-            userId = userId,
-            nickname = req.nickname,
-            neighborhood = req.neighborhood,
-            profilePhotoPath = req.profilePhotoPath,
-        )
+        val user = cb.execute("identity-service") {
+            identityClient.updateUser(
+                userId = userId,
+                nickname = req.nickname,
+                neighborhood = req.neighborhood,
+                profilePhotoPath = req.profilePhotoPath,
+            )
+        }
         return UserResponse(
             id = user.id,
             nickname = user.nickname,
@@ -59,6 +63,6 @@ class UserController(
 
     @DeleteMapping("/me")
     suspend fun deleteMe(@AuthUser userId: Long) {
-        identityClient.deleteUser(userId)
+        cb.execute("identity-service") { identityClient.deleteUser(userId) }
     }
 }

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/WalkController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/WalkController.kt
@@ -10,6 +10,7 @@ import com.mungcle.gateway.dto.WalkResponse
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
 import com.mungcle.gateway.infrastructure.grpc.PetProfileClient
 import com.mungcle.gateway.infrastructure.grpc.WalksClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import com.mungcle.proto.walks.v1.WalkInfo
 import com.mungcle.proto.walks.v1.WalkType
@@ -30,17 +31,18 @@ class WalkController(
     private val walksClient: WalksClient,
     private val identityClient: IdentityClient,
     private val petProfileClient: PetProfileClient,
+    private val cb: CircuitBreakerWrapper,
 ) {
 
     @PostMapping("/start")
     suspend fun startWalk(@AuthUser userId: Long, @Valid @RequestBody req: StartWalkRequest): WalkResponse {
         val walkType = if (req.open) WalkType.WALK_TYPE_OPEN else WalkType.WALK_TYPE_SOLO
-        return walksClient.startWalk(userId, req.dogId, walkType, req.lat, req.lng).toResponse()
+        return cb.execute("walks-service") { walksClient.startWalk(userId, req.dogId, walkType, req.lat, req.lng) }.toResponse()
     }
 
     @PostMapping("/{id}/stop")
     suspend fun stopWalk(@AuthUser userId: Long, @PathVariable id: Long): WalkResponse =
-        walksClient.stopWalk(walkId = id, userId = userId).toResponse()
+        cb.execute("walks-service") { walksClient.stopWalk(walkId = id, userId = userId) }.toResponse()
 
     @GetMapping("/nearby")
     suspend fun getNearbyWalks(
@@ -51,8 +53,8 @@ class WalkController(
         val gridCell = GridCell.fromCoordinates(lat, lng).value
 
         val (blockedUserIds, nearbyWalks) = coroutineScope {
-            val blocked = async { identityClient.getBlockedUserIds(userId) }
-            val walks = async { walksClient.getNearbyWalks(gridCell, userId, emptyList()) }
+            val blocked = async { cb.execute("identity-service") { identityClient.getBlockedUserIds(userId) } }
+            val walks = async { cb.execute("walks-service") { walksClient.getNearbyWalks(gridCell, userId, emptyList()) } }
             blocked.await() to walks.await()
         }
 
@@ -62,8 +64,8 @@ class WalkController(
         val userIds = filteredWalks.map { it.userId }.distinct()
 
         val (dogs, users) = coroutineScope {
-            val dogsDeferred = async { petProfileClient.getDogsByIds(dogIds) }
-            val usersDeferred = async { identityClient.getUsersByIds(userIds) }
+            val dogsDeferred = async { cb.execute("pet-profile-service") { petProfileClient.getDogsByIds(dogIds) } }
+            val usersDeferred = async { cb.execute("identity-service") { identityClient.getUsersByIds(userIds) } }
             dogsDeferred.await() to usersDeferred.await()
         }
 
@@ -99,7 +101,7 @@ class WalkController(
 
     @GetMapping("/me/active")
     suspend fun getMyActiveWalks(@AuthUser userId: Long): List<WalkResponse> =
-        walksClient.getMyActiveWalks(userId).map { it.toResponse() }
+        cb.execute("walks-service") { walksClient.getMyActiveWalks(userId) }.map { it.toResponse() }
 
     private fun WalkInfo.toResponse() = WalkResponse(
         id = id,

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/WalkPatternController.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/api/WalkPatternController.kt
@@ -5,6 +5,7 @@ import com.mungcle.gateway.dto.NearbyPatternsResponse
 import com.mungcle.gateway.dto.PatternResponse
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
 import com.mungcle.gateway.infrastructure.grpc.WalksClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUser
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 class WalkPatternController(
     private val walksClient: WalksClient,
     private val identityClient: IdentityClient,
+    private val cb: CircuitBreakerWrapper,
 ) {
 
     @GetMapping("/nearby")
@@ -25,8 +27,8 @@ class WalkPatternController(
         @RequestParam lng: Double,
     ): NearbyPatternsResponse {
         val gridCell = GridCell.fromCoordinates(lat, lng).value
-        val blockedUserIds = identityClient.getBlockedUserIds(userId)
-        val patterns = walksClient.getNearbyPatterns(gridCell, userId, blockedUserIds)
+        val blockedUserIds = cb.execute("identity-service") { identityClient.getBlockedUserIds(userId) }
+        val patterns = cb.execute("walks-service") { walksClient.getNearbyPatterns(gridCell, userId, blockedUserIds) }
         return NearbyPatternsResponse(patterns.map { pattern ->
             PatternResponse(
                 dogId = pattern.dogId,

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/exception/GlobalExceptionHandler.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/exception/GlobalExceptionHandler.kt
@@ -1,7 +1,9 @@
 package com.mungcle.gateway.infrastructure.exception
 
 import com.mungcle.gateway.infrastructure.grpc.GrpcStatusConverter
+import com.mungcle.gateway.infrastructure.resilience.ServiceUnavailableException
 import io.grpc.StatusException
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -27,6 +29,12 @@ class GlobalExceptionHandler {
             ErrorResponse(400, "VALIDATION_ERROR", fieldErrors)
         )
     }
+
+    @ExceptionHandler(ServiceUnavailableException::class)
+    fun handleServiceUnavailable(e: ServiceUnavailableException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+            .header("Retry-After", "10")
+            .body(ErrorResponse(503, "SERVICE_UNAVAILABLE", e.message ?: "Service temporarily unavailable"))
 }
 
 data class ErrorResponse(

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/resilience/CircuitBreakerWrapper.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/resilience/CircuitBreakerWrapper.kt
@@ -2,14 +2,22 @@ package com.mungcle.gateway.infrastructure.resilience
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
-import io.github.resilience4j.kotlin.circuitbreaker.executeSuspendFunction
+import io.grpc.Status
+import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.TimeUnit
 
 /**
  * gRPC 호출을 Resilience4j Circuit Breaker로 감싸는 유틸리티.
  * Circuit Breaker 상태 전이(CLOSED→OPEN 등)를 로깅하고,
  * 오픈 상태에서 호출 시 ServiceUnavailableException을 발생시킨다.
+ *
+ * 비즈니스 에러(NOT_FOUND, ALREADY_EXISTS 등)는 CB 실패로 기록하지 않는다.
+ * 인프라 장애(UNAVAILABLE, DEADLINE_EXCEEDED, INTERNAL, RESOURCE_EXHAUSTED)만 기록한다.
  */
 @Component
 class CircuitBreakerWrapper(
@@ -17,6 +25,9 @@ class CircuitBreakerWrapper(
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
+
+    // 리스너 중복 등록 방지 — CB 이름별로 등록 여부 추적
+    private val registeredListeners = ConcurrentHashMap.newKeySet<String>()
 
     /**
      * 주어진 서비스 이름의 Circuit Breaker로 suspend 함수를 실행한다.
@@ -28,27 +39,64 @@ class CircuitBreakerWrapper(
      */
     suspend fun <T> execute(serviceName: String, block: suspend () -> T): T {
         val cb = circuitBreakerRegistry.circuitBreaker(serviceName)
-        registerStateTransitionListener(cb)
-        return try {
-            cb.executeSuspendFunction { block() }
-        } catch (e: io.github.resilience4j.circuitbreaker.CallNotPermittedException) {
+        registerIfNeeded(cb)
+
+        if (!cb.tryAcquirePermission()) {
             log.warn("[CircuitBreaker] {} is OPEN — 요청 거부됨", serviceName)
-            throw ServiceUnavailableException(serviceName, e)
+            throw ServiceUnavailableException(
+                serviceName,
+                io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException(cb),
+            )
+        }
+
+        val start = System.nanoTime()
+        return try {
+            val result = block()
+            cb.onSuccess(System.nanoTime() - start, TimeUnit.NANOSECONDS)
+            result
+        } catch (e: Exception) {
+            val duration = System.nanoTime() - start
+            // 인프라 장애만 CB 실패로 기록 — 비즈니스 에러는 기록하지 않음
+            if (shouldRecord(e)) {
+                cb.onError(duration, TimeUnit.NANOSECONDS, e)
+            } else {
+                cb.onSuccess(duration, TimeUnit.NANOSECONDS)
+            }
+            throw e
         }
     }
 
     /**
-     * Circuit Breaker 상태 전이 이벤트를 로깅한다.
-     * 동일 인스턴스에 리스너가 중복 등록되지 않도록 이벤트 발행자 체크.
+     * CB에 기록할 예외인지 판별 — 인프라 장애만 기록.
+     * 비즈니스 에러(NOT_FOUND, ALREADY_EXISTS, PERMISSION_DENIED 등)는 제외한다.
      */
-    private fun registerStateTransitionListener(cb: CircuitBreaker) {
-        cb.eventPublisher.onStateTransition { event ->
-            log.info(
-                "[CircuitBreaker] {} 상태 전이: {} → {}",
-                event.circuitBreakerName,
-                event.stateTransition.fromState,
-                event.stateTransition.toState,
+    private fun shouldRecord(e: Throwable): Boolean {
+        if (e is StatusException || e is StatusRuntimeException) {
+            val status = if (e is StatusException) e.status else (e as StatusRuntimeException).status
+            return status.code in listOf(
+                Status.Code.UNAVAILABLE,
+                Status.Code.DEADLINE_EXCEEDED,
+                Status.Code.INTERNAL,
+                Status.Code.RESOURCE_EXHAUSTED,
             )
+        }
+        return e is TimeoutException
+    }
+
+    /**
+     * Circuit Breaker 상태 전이 이벤트를 로깅한다.
+     * 동일 CB 이름에 대해 최초 1회만 등록한다.
+     */
+    private fun registerIfNeeded(cb: CircuitBreaker) {
+        if (registeredListeners.add(cb.name)) {
+            cb.eventPublisher.onStateTransition { event ->
+                log.warn(
+                    "[CircuitBreaker] {} 상태 전이: {} → {}",
+                    event.circuitBreakerName,
+                    event.stateTransition.fromState,
+                    event.stateTransition.toState,
+                )
+            }
         }
     }
 }

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/resilience/CircuitBreakerWrapper.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/resilience/CircuitBreakerWrapper.kt
@@ -1,0 +1,54 @@
+package com.mungcle.gateway.infrastructure.resilience
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.github.resilience4j.kotlin.circuitbreaker.executeSuspendFunction
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * gRPC 호출을 Resilience4j Circuit Breaker로 감싸는 유틸리티.
+ * Circuit Breaker 상태 전이(CLOSED→OPEN 등)를 로깅하고,
+ * 오픈 상태에서 호출 시 ServiceUnavailableException을 발생시킨다.
+ */
+@Component
+class CircuitBreakerWrapper(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 주어진 서비스 이름의 Circuit Breaker로 suspend 함수를 실행한다.
+     *
+     * @param serviceName resilience4j.circuitbreaker.instances 에 등록된 이름 (예: "identity-service")
+     * @param block 보호할 suspend 함수
+     * @return block 의 반환값
+     * @throws ServiceUnavailableException Circuit Breaker가 OPEN 상태일 때
+     */
+    suspend fun <T> execute(serviceName: String, block: suspend () -> T): T {
+        val cb = circuitBreakerRegistry.circuitBreaker(serviceName)
+        registerStateTransitionListener(cb)
+        return try {
+            cb.executeSuspendFunction { block() }
+        } catch (e: io.github.resilience4j.circuitbreaker.CallNotPermittedException) {
+            log.warn("[CircuitBreaker] {} is OPEN — 요청 거부됨", serviceName)
+            throw ServiceUnavailableException(serviceName, e)
+        }
+    }
+
+    /**
+     * Circuit Breaker 상태 전이 이벤트를 로깅한다.
+     * 동일 인스턴스에 리스너가 중복 등록되지 않도록 이벤트 발행자 체크.
+     */
+    private fun registerStateTransitionListener(cb: CircuitBreaker) {
+        cb.eventPublisher.onStateTransition { event ->
+            log.info(
+                "[CircuitBreaker] {} 상태 전이: {} → {}",
+                event.circuitBreakerName,
+                event.stateTransition.fromState,
+                event.stateTransition.toState,
+            )
+        }
+    }
+}

--- a/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/resilience/ServiceUnavailableException.kt
+++ b/services/api-gateway/src/main/kotlin/com/mungcle/gateway/infrastructure/resilience/ServiceUnavailableException.kt
@@ -1,0 +1,15 @@
+package com.mungcle.gateway.infrastructure.resilience
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+
+/**
+ * Circuit Breaker가 OPEN 상태일 때 발생하는 예외.
+ * GlobalExceptionHandler에서 HTTP 503으로 변환된다.
+ *
+ * @param serviceName 사용 불가 상태인 백엔드 서비스 이름
+ * @param cause 원인 예외 (CallNotPermittedException)
+ */
+class ServiceUnavailableException(
+    val serviceName: String,
+    cause: CallNotPermittedException,
+) : RuntimeException("Service unavailable: $serviceName — circuit breaker is OPEN", cause)

--- a/services/api-gateway/src/main/resources/application.yml
+++ b/services/api-gateway/src/main/resources/application.yml
@@ -29,11 +29,35 @@ jwt:
   secret: ${JWT_SECRET:mungcle-dev-secret-key-change-in-production}
   expiration: 604800000 # 7 days
 
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10s
+        permittedNumberOfCallsInHalfOpenState: 3
+        recordExceptions:
+          - io.grpc.StatusException
+          - io.grpc.StatusRuntimeException
+    instances:
+      identity-service:
+        baseConfig: default
+      pet-profile-service:
+        baseConfig: default
+      walks-service:
+        baseConfig: default
+      social-service:
+        baseConfig: default
+      notification-service:
+        baseConfig: default
+
 management:
   endpoints:
     web:
       exposure:
-        include: health,info,prometheus,metrics
+        include: health,info,prometheus,metrics,circuitbreakers
   metrics:
     distribution:
       percentiles-histogram:

--- a/services/api-gateway/src/main/resources/application.yml
+++ b/services/api-gateway/src/main/resources/application.yml
@@ -38,9 +38,6 @@ resilience4j:
         failureRateThreshold: 50
         waitDurationInOpenState: 10s
         permittedNumberOfCallsInHalfOpenState: 3
-        recordExceptions:
-          - io.grpc.StatusException
-          - io.grpc.StatusRuntimeException
     instances:
       identity-service:
         baseConfig: default

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/AuthControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/AuthControllerTest.kt
@@ -7,12 +7,14 @@ import com.mungcle.gateway.dto.LoginRequest
 import com.mungcle.gateway.dto.RegisterRequest
 import com.mungcle.gateway.dto.SocialLoginRequest
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
 import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
 import com.mungcle.proto.identity.v1.authResponse
 import com.mungcle.proto.identity.v1.userInfo
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -29,6 +31,14 @@ class AuthControllerTest {
 
     @MockkBean
     private lateinit var identityClient: IdentityClient
+
+    @MockkBean
+    private lateinit var cb: CircuitBreakerWrapper
+
+    @BeforeEach
+    fun setupCb() {
+        coEvery { cb.execute(any(), any<suspend () -> Any?>()) } coAnswers { secondArg<suspend () -> Any?>()() }
+    }
 
     private val fakeAuthResponse = authResponse {
         accessToken = "test-jwt-token"

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/BlockControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/BlockControllerTest.kt
@@ -4,6 +4,7 @@ import com.mungcle.gateway.config.SecurityConfig
 import com.mungcle.gateway.config.WebConfig
 import com.mungcle.gateway.dto.CreateBlockRequest
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
 import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
 import com.mungcle.proto.identity.v1.blockInfo
@@ -12,6 +13,7 @@ import com.mungcle.proto.identity.v1.validateTokenResponse
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -28,6 +30,14 @@ class BlockControllerTest {
 
     @MockkBean
     private lateinit var identityClient: IdentityClient
+
+    @MockkBean
+    private lateinit var cb: CircuitBreakerWrapper
+
+    @BeforeEach
+    fun setupCb() {
+        coEvery { cb.execute(any(), any<suspend () -> Any?>()) } coAnswers { secondArg<suspend () -> Any?>()() }
+    }
 
     private fun setupAuth(userId: Long = 1L) {
         val tokenResponse = validateTokenResponse {

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/DogControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/DogControllerTest.kt
@@ -5,6 +5,7 @@ import com.mungcle.gateway.config.WebConfig
 import com.mungcle.gateway.dto.CreateDogRequest
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
 import com.mungcle.gateway.infrastructure.grpc.PetProfileClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
 import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
 import com.mungcle.proto.identity.v1.validateTokenResponse
@@ -12,6 +13,7 @@ import com.mungcle.proto.petprofile.v1.DogSize
 import com.mungcle.proto.petprofile.v1.dogInfo
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -31,6 +33,14 @@ class DogControllerTest {
 
     @MockkBean
     private lateinit var identityClient: IdentityClient
+
+    @MockkBean
+    private lateinit var cb: CircuitBreakerWrapper
+
+    @BeforeEach
+    fun setupCb() {
+        coEvery { cb.execute(any(), any<suspend () -> Any?>()) } coAnswers { secondArg<suspend () -> Any?>()() }
+    }
 
     private val fakeDog = dogInfo {
         id = 1L

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/GreetingControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/GreetingControllerTest.kt
@@ -6,6 +6,7 @@ import com.mungcle.gateway.dto.CreateGreetingRequest
 import com.mungcle.gateway.dto.RespondGreetingRequest
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
 import com.mungcle.gateway.infrastructure.grpc.SocialClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
 import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
 import com.mungcle.proto.identity.v1.validateTokenResponse
@@ -13,6 +14,7 @@ import com.mungcle.proto.social.v1.GreetingStatus
 import com.mungcle.proto.social.v1.greetingInfo
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -32,6 +34,14 @@ class GreetingControllerTest {
 
     @MockkBean
     private lateinit var identityClient: IdentityClient
+
+    @MockkBean
+    private lateinit var cb: CircuitBreakerWrapper
+
+    @BeforeEach
+    fun setupCb() {
+        coEvery { cb.execute(any(), any<suspend () -> Any?>()) } coAnswers { secondArg<suspend () -> Any?>()() }
+    }
 
     private val fakeGreeting = greetingInfo {
         id = 200L

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/NotificationControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/NotificationControllerTest.kt
@@ -4,6 +4,7 @@ import com.mungcle.gateway.config.SecurityConfig
 import com.mungcle.gateway.config.WebConfig
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
 import com.mungcle.gateway.infrastructure.grpc.NotificationClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
 import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
 import com.mungcle.proto.identity.v1.validateTokenResponse
@@ -12,6 +13,7 @@ import com.mungcle.proto.notification.v1.listNotificationsResponse
 import com.mungcle.proto.notification.v1.notificationInfo
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -30,6 +32,14 @@ class NotificationControllerTest {
 
     @MockkBean
     private lateinit var identityClient: IdentityClient
+
+    @MockkBean
+    private lateinit var cb: CircuitBreakerWrapper
+
+    @BeforeEach
+    fun setupCb() {
+        coEvery { cb.execute(any(), any<suspend () -> Any?>()) } coAnswers { secondArg<suspend () -> Any?>()() }
+    }
 
     private val fakeNotification = notificationInfo {
         id = 300L

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/ReportControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/ReportControllerTest.kt
@@ -4,12 +4,14 @@ import com.mungcle.gateway.config.SecurityConfig
 import com.mungcle.gateway.config.WebConfig
 import com.mungcle.gateway.dto.CreateReportRequest
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
 import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
 import com.mungcle.proto.identity.v1.validateTokenResponse
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -26,6 +28,14 @@ class ReportControllerTest {
 
     @MockkBean
     private lateinit var identityClient: IdentityClient
+
+    @MockkBean
+    private lateinit var cb: CircuitBreakerWrapper
+
+    @BeforeEach
+    fun setupCb() {
+        coEvery { cb.execute(any(), any<suspend () -> Any?>()) } coAnswers { secondArg<suspend () -> Any?>()() }
+    }
 
     private fun setupAuth(userId: Long = 1L) {
         val tokenResponse = validateTokenResponse {

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/WalkControllerTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/api/WalkControllerTest.kt
@@ -6,6 +6,7 @@ import com.mungcle.gateway.dto.StartWalkRequest
 import com.mungcle.gateway.infrastructure.grpc.IdentityClient
 import com.mungcle.gateway.infrastructure.grpc.PetProfileClient
 import com.mungcle.gateway.infrastructure.grpc.WalksClient
+import com.mungcle.gateway.infrastructure.resilience.CircuitBreakerWrapper
 import com.mungcle.gateway.infrastructure.security.AuthUserArgumentResolver
 import com.mungcle.gateway.infrastructure.security.JwtAuthenticationFilter
 import com.mungcle.proto.identity.v1.userInfo
@@ -18,6 +19,7 @@ import com.mungcle.proto.walks.v1.nearbyWalkInfo
 import com.mungcle.proto.walks.v1.walkInfo
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.coEvery
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -40,6 +42,14 @@ class WalkControllerTest {
 
     @MockkBean
     private lateinit var petProfileClient: PetProfileClient
+
+    @MockkBean
+    private lateinit var cb: CircuitBreakerWrapper
+
+    @BeforeEach
+    fun setupCb() {
+        coEvery { cb.execute(any(), any<suspend () -> Any?>()) } coAnswers { secondArg<suspend () -> Any?>()() }
+    }
 
     private val fakeWalkInfo = walkInfo {
         id = 100L

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/infrastructure/resilience/CircuitBreakerWrapperTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/infrastructure/resilience/CircuitBreakerWrapperTest.kt
@@ -1,0 +1,74 @@
+package com.mungcle.gateway.infrastructure.resilience
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.grpc.Status
+import io.grpc.StatusException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class CircuitBreakerWrapperTest {
+
+    private lateinit var registry: CircuitBreakerRegistry
+    private lateinit var wrapper: CircuitBreakerWrapper
+
+    @BeforeEach
+    fun setUp() {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowSize(5)
+            .minimumNumberOfCalls(5)
+            .failureRateThreshold(100f) // 100%로 설정하여 5번 실패 후 즉시 오픈
+            .waitDurationInOpenState(Duration.ofSeconds(60))
+            .recordExceptions(StatusException::class.java)
+            .build()
+        registry = CircuitBreakerRegistry.of(config)
+        wrapper = CircuitBreakerWrapper(registry)
+    }
+
+    @Test
+    fun `성공 호출은 결과를 반환한다`() = runTest {
+        val result = wrapper.execute("test-service") { "ok" }
+        assertEquals("ok", result)
+    }
+
+    @Test
+    fun `임계값 이상 실패 시 Circuit Breaker가 OPEN 상태가 된다`() = runTest {
+        val cb = registry.circuitBreaker("threshold-service")
+
+        // 5번 실패 → OPEN 전환
+        repeat(5) {
+            try {
+                wrapper.execute("threshold-service") { throw StatusException(Status.UNAVAILABLE) }
+            } catch (_: StatusException) {
+            }
+        }
+
+        assertEquals(CircuitBreaker.State.OPEN, cb.state)
+    }
+
+    @Test
+    fun `Circuit Breaker가 OPEN 상태일 때 요청은 ServiceUnavailableException으로 거부된다`() = runTest {
+        val cb = registry.circuitBreaker("open-service")
+        cb.transitionToOpenState()
+
+        assertThrows(ServiceUnavailableException::class.java) {
+            kotlinx.coroutines.runBlocking {
+                wrapper.execute("open-service") { "should not reach" }
+            }
+        }
+    }
+
+    @Test
+    fun `Circuit Breaker가 CLOSED 상태일 때 성공 호출은 정상 동작한다`() = runTest {
+        val cb = registry.circuitBreaker("closed-service")
+        assertEquals(CircuitBreaker.State.CLOSED, cb.state)
+
+        val result = wrapper.execute("closed-service") { 42 }
+        assertEquals(42, result)
+    }
+}

--- a/services/api-gateway/src/test/kotlin/com/mungcle/gateway/infrastructure/resilience/CircuitBreakerWrapperTest.kt
+++ b/services/api-gateway/src/test/kotlin/com/mungcle/gateway/infrastructure/resilience/CircuitBreakerWrapperTest.kt
@@ -19,12 +19,12 @@ class CircuitBreakerWrapperTest {
 
     @BeforeEach
     fun setUp() {
+        // recordExceptions는 설정하지 않음 — CircuitBreakerWrapper가 shouldRecord()로 직접 제어
         val config = CircuitBreakerConfig.custom()
             .slidingWindowSize(5)
             .minimumNumberOfCalls(5)
             .failureRateThreshold(100f) // 100%로 설정하여 5번 실패 후 즉시 오픈
             .waitDurationInOpenState(Duration.ofSeconds(60))
-            .recordExceptions(StatusException::class.java)
             .build()
         registry = CircuitBreakerRegistry.of(config)
         wrapper = CircuitBreakerWrapper(registry)
@@ -70,5 +70,20 @@ class CircuitBreakerWrapperTest {
 
         val result = wrapper.execute("closed-service") { 42 }
         assertEquals(42, result)
+    }
+
+    @Test
+    fun `비즈니스 에러(NOT_FOUND)는 CB 실패로 기록되지 않아 OPEN 상태가 되지 않는다`() = runTest {
+        val cb = registry.circuitBreaker("business-error-service")
+
+        // NOT_FOUND 5번 던져도 CB는 CLOSED 유지
+        repeat(5) {
+            try {
+                wrapper.execute("business-error-service") { throw StatusException(Status.NOT_FOUND) }
+            } catch (_: StatusException) {
+            }
+        }
+
+        assertEquals(CircuitBreaker.State.CLOSED, cb.state)
     }
 }


### PR DESCRIPTION
## Summary
- Resilience4j Circuit Breaker 도입 (5개 gRPC 서비스별 인스턴스)
- 모든 컨트롤러 gRPC 호출에 CB 래핑 적용
- CB Open 시 503 + Retry-After 응답
- Actuator endpoint 노출

## Test plan
- [x] CB 임계값 초과 후 Open 전환 테스트
- [x] Open 상태에서 요청 거부 (503) 테스트
- [x] `./gradlew :services:api-gateway:test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)