### PR TITLE
MC-50: 프론트엔드 장애 대응 UI

### DIFF
--- a/frontend/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React, { useState } from 'react';
+import { Text } from 'react-native';
+import { ErrorBoundary } from '../src/shared/components/ErrorBoundary';
+
+// 외부에서 에러 발생 여부를 제어할 수 있는 테스트용 컴포넌트
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('테스트 에러');
+  return <Text>정상 콘텐츠</Text>;
+}
+
+function ThrowNetworkError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('Network request failed');
+  return <Text>정상 콘텐츠</Text>;
+}
+
+// console.error 억제 — React error boundary 테스트 시 불필요한 출력 방지
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('ErrorBoundary', () => {
+  it('에러 없으면 자식 컴포넌트를 렌더링함', () => {
+    const { getByText } = render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(getByText('정상 콘텐츠')).toBeTruthy();
+  });
+
+  it('렌더 에러 발생 시 기본 에러 화면을 표시함', () => {
+    const { getByText } = render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(getByText('오류가 발생했어요')).toBeTruthy();
+    expect(getByText('잠시 후 다시 시도해주세요')).toBeTruthy();
+  });
+
+  it('네트워크 에러 발생 시 연결 오류 화면을 표시함', () => {
+    const { getByText } = render(
+      <ErrorBoundary>
+        <ThrowNetworkError shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(getByText('연결할 수 없어요')).toBeTruthy();
+  });
+
+  it('다시 시도 버튼 클릭 시 onRetry가 호출됨', () => {
+    const onRetry = jest.fn();
+    const { getByLabelText } = render(
+      <ErrorBoundary onRetry={onRetry}>
+        <ThrowError shouldThrow />
+      </ErrorBoundary>,
+    );
+    fireEvent.press(getByLabelText('다시 시도'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('커스텀 fallback prop이 있으면 fallback UI를 렌더링함', () => {
+    const fallback = jest.fn(() => <Text>커스텀 에러 UI</Text>);
+    const { getByText } = render(
+      <ErrorBoundary fallback={fallback}>
+        <ThrowError shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(getByText('커스텀 에러 UI')).toBeTruthy();
+    // React가 error recovery 과정에서 두 번 호출할 수 있음
+    expect(fallback).toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/ErrorState.test.tsx
+++ b/frontend/__tests__/ErrorState.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { ErrorState } from '../src/shared/components/ErrorState';
+
+describe('ErrorState', () => {
+  it('기본(generic) 변형 — 기본 타이틀/메시지 렌더링', () => {
+    const { getByText } = render(<ErrorState />);
+    expect(getByText('오류가 발생했어요')).toBeTruthy();
+    expect(getByText('잠시 후 다시 시도해주세요')).toBeTruthy();
+  });
+
+  it('network 변형 — 네트워크 메시지 렌더링', () => {
+    const { getByText } = render(<ErrorState variant="network" />);
+    expect(getByText('연결할 수 없어요')).toBeTruthy();
+  });
+
+  it('server 변형 — 서버 오류 메시지 렌더링', () => {
+    const { getByText } = render(<ErrorState variant="server" />);
+    expect(getByText('서버 오류')).toBeTruthy();
+  });
+
+  it('notFound 변형 — 찾을 수 없음 메시지 렌더링', () => {
+    const { getByText } = render(<ErrorState variant="notFound" />);
+    expect(getByText('찾을 수 없어요')).toBeTruthy();
+  });
+
+  it('message prop으로 기본 메시지 오버라이드 가능', () => {
+    const { getByText } = render(<ErrorState message="커스텀 에러 메시지" />);
+    expect(getByText('커스텀 에러 메시지')).toBeTruthy();
+  });
+
+  it('onRetry가 있으면 다시 시도 버튼 렌더링', () => {
+    const onRetry = jest.fn();
+    const { getByLabelText } = render(<ErrorState onRetry={onRetry} />);
+    expect(getByLabelText('다시 시도')).toBeTruthy();
+  });
+
+  it('onRetry가 없으면 버튼 미렌더링', () => {
+    const { queryByLabelText } = render(<ErrorState />);
+    expect(queryByLabelText('다시 시도')).toBeNull();
+  });
+
+  it('다시 시도 버튼 클릭 시 onRetry 호출', () => {
+    const onRetry = jest.fn();
+    const { getByLabelText } = render(<ErrorState onRetry={onRetry} />);
+    fireEvent.press(getByLabelText('다시 시도'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/__tests__/useRetry.test.ts
+++ b/frontend/__tests__/useRetry.test.ts
@@ -1,0 +1,79 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useRetry } from '../src/shared/hooks/useRetry';
+
+// 지수 백오프 sleep을 건너뛰기 위해 실제 setTimeout을 즉시 실행으로 교체
+beforeAll(() => {
+  jest
+    .spyOn(global, 'setTimeout')
+    .mockImplementation((fn: TimerHandler, _delay?: number, ..._args: unknown[]) => {
+      if (typeof fn === 'function') (fn as () => void)();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+});
+
+afterAll(() => {
+  (global.setTimeout as jest.MockedFunction<typeof setTimeout>).mockRestore();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useRetry', () => {
+  it('성공 시 data를 반환하고 error는 null', async () => {
+    const asyncFn = jest.fn().mockResolvedValue({ id: 1 });
+    const { result } = renderHook(() => useRetry(asyncFn, { maxRetries: 3 }));
+
+    act(() => { result.current.retry(); });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual({ id: 1 });
+    expect(result.current.error).toBeNull();
+    expect(asyncFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('maxRetries 초과 시 error를 설정하고 data는 null', async () => {
+    const asyncFn = jest.fn().mockRejectedValue(new Error('서버 오류'));
+    const { result } = renderHook(() =>
+      useRetry(asyncFn, { maxRetries: 2, initialDelayMs: 1 }),
+    );
+
+    act(() => { result.current.retry(); });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 5000 });
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.data).toBeNull();
+    // 최초 1회 + 재시도 2회 = 3회
+    expect(asyncFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('retry 재호출 시 retryCount가 0으로 초기화됨', async () => {
+    const asyncFn = jest.fn().mockResolvedValue('ok');
+    const { result } = renderHook(() => useRetry(asyncFn));
+
+    act(() => { result.current.retry(); });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.retryCount).toBe(0);
+  });
+
+  it('isLoading — 실행 중 true, 완료 후 false', async () => {
+    let resolve!: (v: string) => void;
+    const asyncFn = jest.fn(
+      () => new Promise<string>((res) => { resolve = res; }),
+    );
+    const { result } = renderHook(() => useRetry(asyncFn));
+
+    act(() => { result.current.retry(); });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => { resolve('done'); });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBe('done');
+  });
+});

--- a/frontend/src/features/social/types/social.types.ts
+++ b/frontend/src/features/social/types/social.types.ts
@@ -1,4 +1,4 @@
-export type GreetingStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED';
+export type GreetingStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'EXPIRED';
 
 export interface GreetingResponse {
   id: number;

--- a/frontend/src/shared/components/EmptyState.tsx
+++ b/frontend/src/shared/components/EmptyState.tsx
@@ -18,15 +18,16 @@ export function EmptyState({ icon, message, ctaLabel, onCta }: EmptyStateProps) 
       {icon ? <Text style={styles.icon}>{icon}</Text> : null}
       <Text style={styles.message}>{message}</Text>
       {ctaLabel && onCta ? (
-        <Button
-          variant="outline"
-          size="md"
-          onPress={onCta}
-          accessibilityLabel={ctaLabel}
-          style={styles.cta}
-        >
-          {ctaLabel}
-        </Button>
+        <View style={styles.cta}>
+          <Button
+            variant="outline"
+            size="md"
+            onPress={onCta}
+            accessibilityLabel={ctaLabel}
+          >
+            {ctaLabel}
+          </Button>
+        </View>
       ) : null}
     </View>
   );

--- a/frontend/src/shared/components/ErrorBoundary.tsx
+++ b/frontend/src/shared/components/ErrorBoundary.tsx
@@ -6,17 +6,20 @@ import { typography } from '../../constants/typography';
 interface Props {
   children: React.ReactNode;
   onRetry?: () => void;
+  // 커스텀 폴백 UI — ReactNode 또는 렌더 함수(error, retry) 모두 허용
+  fallback?: React.ReactNode | ((error: Error, retry: () => void) => React.ReactNode);
 }
 
 interface State {
   hasError: boolean;
+  error: Error | null;
   isNetworkError: boolean;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, isNetworkError: false };
+    this.state = { hasError: false, error: null, isNetworkError: false };
   }
 
   static getDerivedStateFromError(error: Error): State {
@@ -25,27 +28,46 @@ export class ErrorBoundary extends Component<Props, State> {
       error.message.includes('Network') ||
       error.message.includes('fetch') ||
       error.message.includes('연결');
-    return { hasError: true, isNetworkError };
+    return { hasError: true, error, isNetworkError };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // 렌더 에러 로깅 — 프로덕션에서는 Sentry 등으로 대체
+    console.error('[ErrorBoundary] render error:', error.message, info.componentStack);
   }
 
   handleRetry = () => {
-    this.setState({ hasError: false, isNetworkError: false });
+    this.setState({ hasError: false, error: null, isNetworkError: false });
     this.props.onRetry?.();
   };
 
   render() {
-    if (!this.state.hasError) {
-      return this.props.children;
+    const { hasError, error, isNetworkError } = this.state;
+    const { children, fallback } = this.props;
+
+    if (!hasError) {
+      return children;
+    }
+
+    // 커스텀 폴백 처리 — 렌더 함수 또는 ReactNode 모두 지원
+    if (fallback !== undefined) {
+      if (typeof fallback === 'function') {
+        return (fallback as (error: Error, retry: () => void) => React.ReactNode)(
+          error ?? new Error('Unknown error'),
+          this.handleRetry,
+        );
+      }
+      return fallback;
     }
 
     return (
       <View style={styles.container}>
-        <Text style={styles.icon}>{this.state.isNetworkError ? '📡' : '⚠️'}</Text>
+        <Text style={styles.icon}>{isNetworkError ? '📡' : '⚠️'}</Text>
         <Text style={styles.title}>
-          {this.state.isNetworkError ? '연결할 수 없어요' : '오류가 발생했어요'}
+          {isNetworkError ? '연결할 수 없어요' : '오류가 발생했어요'}
         </Text>
         <Text style={styles.message}>
-          {this.state.isNetworkError
+          {isNetworkError
             ? '인터넷 연결을 확인하고 다시 시도해주세요'
             : '잠시 후 다시 시도해주세요'}
         </Text>

--- a/frontend/src/shared/components/ErrorState.tsx
+++ b/frontend/src/shared/components/ErrorState.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, spacing } from '../../constants/theme';
+import { typography } from '../../constants/typography';
+import { Button } from './Button';
+
+type ErrorVariant = 'network' | 'server' | 'notFound' | 'generic';
+
+interface ErrorStateProps {
+  variant?: ErrorVariant;
+  // 메시지 오버라이드 — 미제공 시 variant 기본 메시지 사용
+  message?: string;
+  onRetry?: () => void;
+}
+
+const VARIANT_CONFIG: Record<ErrorVariant, { icon: string; title: string; message: string }> = {
+  network: {
+    icon: '📡',
+    title: '연결할 수 없어요',
+    message: '인터넷 연결을 확인하고 다시 시도해주세요',
+  },
+  server: {
+    icon: '🔧',
+    title: '서버 오류',
+    message: '서버에 문제가 생겼어요. 잠시 후 다시 시도해주세요',
+  },
+  notFound: {
+    icon: '🔍',
+    title: '찾을 수 없어요',
+    message: '요청하신 정보를 찾을 수 없어요',
+  },
+  generic: {
+    icon: '⚠️',
+    title: '오류가 발생했어요',
+    message: '잠시 후 다시 시도해주세요',
+  },
+};
+
+// 데이터 화면 공통 에러 상태 컴포넌트 — variant별 아이콘/메시지 + 재시도 버튼
+export function ErrorState({ variant = 'generic', message, onRetry }: ErrorStateProps) {
+  const config = VARIANT_CONFIG[variant];
+
+  return (
+    <View style={styles.container} accessibilityRole="none">
+      <Text style={styles.icon} accessibilityElementsHidden>
+        {config.icon}
+      </Text>
+      <Text style={styles.title}>{config.title}</Text>
+      <Text style={styles.message}>{message ?? config.message}</Text>
+      {onRetry ? (
+        <View style={styles.retryButton}>
+          <Button
+            variant="outline"
+            size="md"
+            onPress={onRetry}
+            accessibilityLabel="다시 시도"
+          >
+            다시 시도
+          </Button>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.lg,
+  },
+  icon: {
+    fontSize: 48,
+    marginBottom: spacing.md,
+  },
+  title: {
+    ...typography.subheading,
+    color: colors.text,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  message: {
+    ...typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+    marginBottom: spacing.lg,
+  },
+  retryButton: {
+    minWidth: 120,
+  },
+});

--- a/frontend/src/shared/components/OfflineBanner.tsx
+++ b/frontend/src/shared/components/OfflineBanner.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
+import { colors, spacing } from '../../constants/theme';
+import { typography } from '../../constants/typography';
+
+// 네트워크 상태 감지 — expo-network 없이 fetch probe 방식 사용
+async function checkOnline(): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    await fetch('https://clients3.google.com/generate_204', {
+      method: 'HEAD',
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    clearTimeout(timeout);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const POLL_INTERVAL_MS = 5000;
+
+// 오프라인 상태일 때 상단에 표시되는 배너 — 연결 복구 시 자동으로 사라짐
+export function OfflineBanner() {
+  const [isOffline, setIsOffline] = useState(false);
+  const translateY = useRef(new Animated.Value(-60)).current;
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function poll() {
+      const online = await checkOnline();
+      if (!mounted) return;
+      setIsOffline(!online);
+    }
+
+    poll();
+    const interval = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  useEffect(() => {
+    Animated.timing(translateY, {
+      toValue: isOffline ? 0 : -60,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [isOffline, translateY]);
+
+  return (
+    <Animated.View
+      style={[styles.banner, { transform: [{ translateY }] }]}
+      accessibilityLabel="오프라인 상태입니다"
+      accessibilityLiveRegion="polite"
+      pointerEvents="none"
+    >
+      <Text style={styles.text}>인터넷 연결이 없어요</Text>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: colors.warning,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    alignItems: 'center',
+    zIndex: 999,
+  },
+  text: {
+    ...typography.caption,
+    color: colors.surface,
+    fontWeight: '600',
+  },
+});

--- a/frontend/src/shared/components/SkeletonLoader.tsx
+++ b/frontend/src/shared/components/SkeletonLoader.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, View, type ViewStyle } from 'react-native';
+import { colors, borderRadius, spacing } from '../../constants/theme';
+
+type SkeletonShape = 'line' | 'circle' | 'card';
+
+interface SkeletonLoaderProps {
+  shape?: SkeletonShape;
+  width?: number | `${number}%`;
+  height?: number;
+  style?: ViewStyle;
+}
+
+// 콘텐츠 로딩 중 애니메이션 플레이스홀더 — React Native Animated API 사용 (외부 의존성 없음)
+export function SkeletonLoader({ shape = 'line', width, height, style }: SkeletonLoaderProps) {
+  const opacity = useRef(new Animated.Value(0.4)).current;
+
+  useEffect(() => {
+    // 명도 0.4 ↔ 1.0 반복 페이드 애니메이션
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.4,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [opacity]);
+
+  const shapeStyle = getShapeStyle(shape, width, height);
+
+  return (
+    <Animated.View
+      style={[styles.base, shapeStyle, style, { opacity }]}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    />
+  );
+}
+
+function getShapeStyle(
+  shape: SkeletonShape,
+  width?: number | `${number}%`,
+  height?: number,
+): ViewStyle {
+  switch (shape) {
+    case 'circle': {
+      const size = height ?? 48;
+      return {
+        width: width ?? size,
+        height: size,
+        borderRadius: size / 2,
+      };
+    }
+    case 'card':
+      return {
+        width: width ?? '100%',
+        height: height ?? 120,
+        borderRadius: borderRadius.card,
+      };
+    case 'line':
+    default:
+      return {
+        width: width ?? '100%',
+        height: height ?? 14,
+        borderRadius: 6,
+      };
+  }
+}
+
+// 카드형 스켈레톤 — 아바타 + 텍스트 라인 조합
+export function SkeletonCard() {
+  return (
+    <View style={skeletonCardStyles.container}>
+      <SkeletonLoader shape="circle" height={56} />
+      <View style={skeletonCardStyles.lines}>
+        <SkeletonLoader shape="line" width="60%" height={14} />
+        <SkeletonLoader shape="line" width="40%" height={12} style={{ marginTop: spacing.sm }} />
+        <SkeletonLoader shape="line" width="80%" height={12} style={{ marginTop: spacing.sm }} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    backgroundColor: colors.border,
+  },
+});
+
+const skeletonCardStyles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    padding: spacing.md,
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.card,
+    marginBottom: spacing.sm,
+  },
+  lines: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+});

--- a/frontend/src/shared/hooks/useRetry.ts
+++ b/frontend/src/shared/hooks/useRetry.ts
@@ -1,0 +1,68 @@
+import { useCallback, useRef, useState } from 'react';
+
+interface UseRetryOptions {
+  maxRetries?: number;
+  // 첫 재시도 대기 시간(ms) — 이후 지수 증가
+  initialDelayMs?: number;
+}
+
+interface UseRetryResult<T> {
+  data: T | null;
+  error: Error | null;
+  isLoading: boolean;
+  retryCount: number;
+  retry: () => void;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function useRetry<T>(
+  asyncFn: () => Promise<T>,
+  options: UseRetryOptions = {},
+): UseRetryResult<T> {
+  const { maxRetries = 3, initialDelayMs = 1000 } = options;
+
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
+  // 최신 asyncFn 참조를 유지 — 클로저 stale 방지
+  const asyncFnRef = useRef(asyncFn);
+  asyncFnRef.current = asyncFn;
+
+  const execute = useCallback(
+    async (attempt: number) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await asyncFnRef.current();
+        setData(result);
+        setError(null);
+      } catch (err) {
+        const caughtError = err instanceof Error ? err : new Error(String(err));
+        if (attempt < maxRetries) {
+          // 지수 백오프: initialDelayMs * 2^attempt (최대 30초)
+          const delay = Math.min(initialDelayMs * Math.pow(2, attempt), 30_000);
+          await sleep(delay);
+          setRetryCount(attempt + 1);
+          await execute(attempt + 1);
+          return;
+        }
+        setError(caughtError);
+        setData(null);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [maxRetries, initialDelayMs],
+  );
+
+  const retry = useCallback(() => {
+    setRetryCount(0);
+    execute(0);
+  }, [execute]);
+
+  return { data, error, isLoading, retryCount, retry };
+}

--- a/frontend/src/shared/hooks/useRetry.ts
+++ b/frontend/src/shared/hooks/useRetry.ts
@@ -32,36 +32,35 @@ export function useRetry<T>(
   const asyncFnRef = useRef(asyncFn);
   asyncFnRef.current = asyncFn;
 
-  const execute = useCallback(
-    async (attempt: number) => {
-      setIsLoading(true);
-      setError(null);
+  const execute = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setRetryCount(0);
+
+    // 재귀 대신 for 루프 사용 — finally가 각 호출마다 실행되던 isLoading 깜빡임 방지
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
         const result = await asyncFnRef.current();
         setData(result);
-        setError(null);
+        setIsLoading(false);
+        return;
       } catch (err) {
-        const caughtError = err instanceof Error ? err : new Error(String(err));
         if (attempt < maxRetries) {
           // 지수 백오프: initialDelayMs * 2^attempt (최대 30초)
           const delay = Math.min(initialDelayMs * Math.pow(2, attempt), 30_000);
-          await sleep(delay);
           setRetryCount(attempt + 1);
-          await execute(attempt + 1);
-          return;
+          await sleep(delay);
+        } else {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setData(null);
+          setIsLoading(false);
         }
-        setError(caughtError);
-        setData(null);
-      } finally {
-        setIsLoading(false);
       }
-    },
-    [maxRetries, initialDelayMs],
-  );
+    }
+  }, [maxRetries, initialDelayMs]);
 
   const retry = useCallback(() => {
-    setRetryCount(0);
-    execute(0);
+    execute();
   }, [execute]);
 
   return { data, error, isLoading, retryCount, retry };


### PR DESCRIPTION
## Summary
- ErrorBoundary, ErrorState, SkeletonLoader, OfflineBanner 컴포넌트
- useRetry 훅 (지수 백오프 재시도)
- API 인터셉터 (503/429/네트워크 에러 처리)
- dogs 화면에 패턴 적용

## Test plan
- [x] `npm test` 75 tests 통과
- [x] TypeScript 컴파일 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)