### PR TITLE
MC-51: CB 상태 모니터링 — Grafana 대시보드 + 알림

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       - grafana-data:/var/lib/grafana
       - ./infra/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./infra/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./infra/grafana/provisioning/alerting:/etc/grafana/provisioning/alerting:ro
       - ./infra/grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - prometheus

--- a/infra/grafana/dashboards/mungcle-circuit-breaker.json
+++ b/infra/grafana/dashboards/mungcle-circuit-breaker.json
@@ -1,0 +1,349 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "멍클 API Gateway — Resilience4j Circuit Breaker 상태, 실패율, 호출 결과, 느린 호출률",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["mungcle"],
+      "targetBlank": false,
+      "title": "Mungcle Overview",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Circuit Breaker — 현재 상태",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "mappings": [
+            { "options": { "0": { "color": "green", "index": 0, "text": "CLOSED" } }, "type": "value" },
+            { "options": { "0.5": { "color": "yellow", "index": 1, "text": "HALF_OPEN" } }, "type": "value" },
+            { "options": { "1": { "color": "red", "index": 2, "text": "OPEN" } }, "type": "value" }
+          ],
+          "unit": "short",
+          "noValue": "N/A"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "name",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "max(resilience4j_circuitbreaker_state{name=~\"$circuitbreaker\"}) by (name) * 0 + (max(resilience4j_circuitbreaker_state{name=~\"$circuitbreaker\",state=\"open\"}) by (name) * 1 or max(resilience4j_circuitbreaker_state{name=~\"$circuitbreaker\",state=\"half_open\"}) by (name) * 0.5 or max(resilience4j_circuitbreaker_state{name=~\"$circuitbreaker\",state=\"closed\"}) by (name) * 0)",
+          "legendFormat": "{{name}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Circuit Breaker 상태 (CLOSED=녹색 / HALF_OPEN=노랑 / OPEN=빨강)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 101,
+      "title": "Circuit Breaker — 실패율 & 느린 호출률",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "resilience4j_circuitbreaker_failure_rate{name=~\"$circuitbreaker\"}",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "실패율 (%) — CB 인스턴스별",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "resilience4j_circuitbreaker_slow_call_rate{name=~\"$circuitbreaker\"}",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "느린 호출률 (%) — CB 인스턴스별",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+      "id": 102,
+      "title": "Circuit Breaker — 호출 결과",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byFrameRefID", "options": "success" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byFrameRefID", "options": "failed" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byFrameRefID", "options": "not_permitted" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 17 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(resilience4j_circuitbreaker_calls_seconds_count{name=~\"$circuitbreaker\",kind=\"successful\"}[1m])) by (name)",
+          "legendFormat": "{{name}} — 성공",
+          "refId": "success"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(resilience4j_circuitbreaker_calls_seconds_count{name=~\"$circuitbreaker\",kind=\"failed\"}[1m])) by (name)",
+          "legendFormat": "{{name}} — 실패",
+          "refId": "failed"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(resilience4j_circuitbreaker_calls_seconds_count{name=~\"$circuitbreaker\",kind=\"not_permitted\"}[1m])) by (name)",
+          "legendFormat": "{{name}} — 차단됨",
+          "refId": "not_permitted"
+        }
+      ],
+      "title": "호출 결과 (req/s) — 성공 / 실패 / 차단됨",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
+      "id": 103,
+      "title": "Circuit Breaker — 버퍼 & 지연",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 5 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "resilience4j_circuitbreaker_buffered_calls{name=~\"$circuitbreaker\",kind=\"successful\"}",
+          "legendFormat": "{{name}} — 성공 버퍼",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "resilience4j_circuitbreaker_buffered_calls{name=~\"$circuitbreaker\",kind=\"failed\"}",
+          "legendFormat": "{{name}} — 실패 버퍼",
+          "refId": "B"
+        }
+      ],
+      "title": "버퍼된 호출 수 — 슬라이딩 윈도우",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 5 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum(rate(resilience4j_circuitbreaker_calls_seconds_bucket{name=~\"$circuitbreaker\"}[5m])) by (name, le))",
+          "legendFormat": "{{name}} p99",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(resilience4j_circuitbreaker_calls_seconds_bucket{name=~\"$circuitbreaker\"}[5m])) by (name, le))",
+          "legendFormat": "{{name}} p95",
+          "refId": "B"
+        }
+      ],
+      "title": "호출 지연 P95/P99 — CB 인스턴스별",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["mungcle", "circuit-breaker", "resilience4j", "api-gateway"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(resilience4j_circuitbreaker_state, name)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "circuitbreaker",
+        "options": [],
+        "query": {
+          "query": "label_values(resilience4j_circuitbreaker_state, name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "label": "Circuit Breaker",
+        "allValue": ".*"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mungcle — Circuit Breaker 모니터링",
+  "uid": "mungcle-circuit-breaker",
+  "version": 1
+}

--- a/infra/grafana/provisioning/alerting/circuit-breaker-alerts.yaml
+++ b/infra/grafana/provisioning/alerting/circuit-breaker-alerts.yaml
@@ -1,0 +1,123 @@
+apiVersion: 1
+
+# Circuit Breaker 알림 규칙 — Resilience4j CB 상태 전환, 실패율, P99 지연 임계치 초과 시 알림
+groups:
+  - orgId: 1
+    name: circuit-breaker
+    folder: Mungcle Alerts
+    interval: 1m
+    rules:
+
+      # CB가 OPEN 상태로 전환될 때 즉시 알림
+      - uid: cb-state-open
+        title: Circuit Breaker OPEN 상태 전환
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 120, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: max(resilience4j_circuitbreaker_state{state="open"}) by (name)
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 120, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        dashboardUid: mungcle-circuit-breaker
+        panelId: 1
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        annotations:
+          summary: "Circuit Breaker {{ $labels.name }} 가 OPEN 상태로 전환됨"
+          description: "api-gateway 의 {{ $labels.name }} circuit breaker 가 OPEN 상태입니다. 즉시 확인이 필요합니다."
+        labels:
+          severity: critical
+          team: backend
+
+      # 실패율이 2분 이상 50%를 초과할 때 알림
+      - uid: cb-failure-rate-high
+        title: Circuit Breaker 실패율 50% 초과
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: resilience4j_circuitbreaker_failure_rate
+              instant: false
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [50], type: gt }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        dashboardUid: mungcle-circuit-breaker
+        panelId: 2
+        noDataState: OK
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          summary: "Circuit Breaker {{ $labels.name }} 실패율 {{ $values.A }}% 초과"
+          description: "{{ $labels.name }} circuit breaker 의 실패율이 2분 이상 50%를 초과하고 있습니다."
+        labels:
+          severity: warning
+          team: backend
+
+      # P99 지연이 5분 이상 3초를 초과할 때 알림
+      - uid: cb-p99-latency-high
+        title: Circuit Breaker P99 지연 3초 초과
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: histogram_quantile(0.99, sum(rate(resilience4j_circuitbreaker_calls_seconds_bucket[5m])) by (name, le))
+              instant: false
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator: { params: [3], type: gt }
+                  operator: { type: and }
+                  query: { params: [A] }
+                  reducer: { params: [], type: last }
+                  type: query
+              datasource: { type: __expr__, uid: __expr__ }
+              expression: A
+              refId: C
+              type: threshold
+        dashboardUid: mungcle-circuit-breaker
+        panelId: 6
+        noDataState: OK
+        execErrState: Alerting
+        for: 5m
+        annotations:
+          summary: "Circuit Breaker {{ $labels.name }} P99 지연 {{ $values.A }}s 초과"
+          description: "{{ $labels.name }} circuit breaker 의 P99 지연이 5분 이상 3초를 초과하고 있습니다."
+        labels:
+          severity: warning
+          team: backend


### PR DESCRIPTION
Resilience4j CB 전용 Grafana 대시보드 6패널 + 알림 규칙 3개