### PR TITLE
refactor(grpc): gRPC 서비스 풀 패키지 경로를 import alias로 리팩터링

### DIFF
--- a/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/IdentityAuthGrpcService.kt
+++ b/services/identity/src/main/kotlin/com/mungcle/identity/infrastructure/grpc/server/IdentityAuthGrpcService.kt
@@ -46,6 +46,7 @@ import com.mungcle.proto.identity.v1.UpdatePushTokenResponse
 import com.mungcle.proto.identity.v1.UpdateUserRequest
 import com.mungcle.proto.identity.v1.UserInfo
 import com.mungcle.proto.identity.v1.ValidateTokenRequest
+import com.mungcle.proto.identity.v1.SocialProvider as ProtoSocialProvider
 import com.mungcle.proto.identity.v1.ValidateTokenResponse
 import com.mungcle.proto.identity.v1.authResponse
 import com.mungcle.proto.identity.v1.blockInfo
@@ -94,10 +95,10 @@ class IdentityAuthGrpcService(
 
     override suspend fun authenticateSocial(request: AuthenticateSocialRequest): AuthResponse {
         val provider = when (request.provider) {
-            com.mungcle.proto.identity.v1.SocialProvider.SOCIAL_PROVIDER_KAKAO -> SocialProvider.KAKAO
-            com.mungcle.proto.identity.v1.SocialProvider.SOCIAL_PROVIDER_NAVER -> SocialProvider.NAVER
-            com.mungcle.proto.identity.v1.SocialProvider.SOCIAL_PROVIDER_APPLE -> SocialProvider.APPLE
-            com.mungcle.proto.identity.v1.SocialProvider.SOCIAL_PROVIDER_GOOGLE -> SocialProvider.GOOGLE
+            ProtoSocialProvider.SOCIAL_PROVIDER_KAKAO -> SocialProvider.KAKAO
+            ProtoSocialProvider.SOCIAL_PROVIDER_NAVER -> SocialProvider.NAVER
+            ProtoSocialProvider.SOCIAL_PROVIDER_APPLE -> SocialProvider.APPLE
+            ProtoSocialProvider.SOCIAL_PROVIDER_GOOGLE -> SocialProvider.GOOGLE
             else -> throw StatusException(Status.INVALID_ARGUMENT.withDescription("지원하지 않는 소셜 로그인 프로바이더입니다"))
         }
         val result = authenticateSocialUseCase.execute(

--- a/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/grpc/server/NotificationGrpcService.kt
+++ b/services/notification/src/main/kotlin/com/mungcle/notification/infrastructure/grpc/server/NotificationGrpcService.kt
@@ -13,6 +13,7 @@ import com.mungcle.proto.notification.v1.MarkAllReadResponse
 import com.mungcle.proto.notification.v1.MarkReadRequest
 import com.mungcle.proto.notification.v1.MarkReadResponse
 import com.mungcle.proto.notification.v1.NotificationInfo
+import com.mungcle.proto.notification.v1.NotificationType as ProtoNotificationType
 import com.mungcle.proto.notification.v1.NotificationServiceGrpcKt
 import com.mungcle.proto.notification.v1.listNotificationsResponse
 import com.mungcle.proto.notification.v1.notificationInfo
@@ -75,10 +76,10 @@ class NotificationGrpcService(
         createdAt = this@toProto.createdAt.epochSecond
     }
 
-    private fun NotificationType.toProto(): com.mungcle.proto.notification.v1.NotificationType = when (this) {
-        NotificationType.GREETING_RECEIVED -> com.mungcle.proto.notification.v1.NotificationType.NOTIFICATION_TYPE_GREETING_RECEIVED
-        NotificationType.GREETING_ACCEPTED -> com.mungcle.proto.notification.v1.NotificationType.NOTIFICATION_TYPE_GREETING_ACCEPTED
-        NotificationType.MESSAGE_RECEIVED -> com.mungcle.proto.notification.v1.NotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED
-        NotificationType.WALK_EXPIRED -> com.mungcle.proto.notification.v1.NotificationType.NOTIFICATION_TYPE_WALK_EXPIRED
+    private fun NotificationType.toProto(): ProtoNotificationType = when (this) {
+        NotificationType.GREETING_RECEIVED -> ProtoNotificationType.NOTIFICATION_TYPE_GREETING_RECEIVED
+        NotificationType.GREETING_ACCEPTED -> ProtoNotificationType.NOTIFICATION_TYPE_GREETING_ACCEPTED
+        NotificationType.MESSAGE_RECEIVED -> ProtoNotificationType.NOTIFICATION_TYPE_MESSAGE_RECEIVED
+        NotificationType.WALK_EXPIRED -> ProtoNotificationType.NOTIFICATION_TYPE_WALK_EXPIRED
     }
 }

--- a/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/grpc/server/PetProfileGrpcService.kt
+++ b/services/pet-profile/src/main/kotlin/com/mungcle/petprofile/infrastructure/grpc/server/PetProfileGrpcService.kt
@@ -14,6 +14,7 @@ import com.mungcle.petprofile.domain.port.`in`.UpdateDogUseCase
 import com.mungcle.proto.petprofile.v1.CreateDogRequest
 import com.mungcle.proto.petprofile.v1.DeleteDogRequest
 import com.mungcle.proto.petprofile.v1.DeleteDogResponse
+import com.mungcle.proto.petprofile.v1.DogSize as ProtoDogSize
 import com.mungcle.proto.petprofile.v1.DogInfo
 import com.mungcle.proto.petprofile.v1.GetDogRequest
 import com.mungcle.proto.petprofile.v1.GetDogsByIdsRequest
@@ -131,16 +132,16 @@ class PetProfileGrpcService(
         vaccinationRegistered = this@toDogInfo.isVaccinationRegistered()
     }
 
-    private fun mapDogSize(protoSize: com.mungcle.proto.petprofile.v1.DogSize): DogSize = when (protoSize) {
-        com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_SMALL -> DogSize.SMALL
-        com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_MEDIUM -> DogSize.MEDIUM
-        com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_LARGE -> DogSize.LARGE
+    private fun mapDogSize(protoSize: ProtoDogSize): DogSize = when (protoSize) {
+        ProtoDogSize.DOG_SIZE_SMALL -> DogSize.SMALL
+        ProtoDogSize.DOG_SIZE_MEDIUM -> DogSize.MEDIUM
+        ProtoDogSize.DOG_SIZE_LARGE -> DogSize.LARGE
         else -> throw IllegalArgumentException("유효하지 않은 반려견 크기입니다: $protoSize")
     }
 
-    private fun mapDogSizeToProto(size: DogSize): com.mungcle.proto.petprofile.v1.DogSize = when (size) {
-        DogSize.SMALL -> com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_SMALL
-        DogSize.MEDIUM -> com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_MEDIUM
-        DogSize.LARGE -> com.mungcle.proto.petprofile.v1.DogSize.DOG_SIZE_LARGE
+    private fun mapDogSizeToProto(size: DogSize): ProtoDogSize = when (size) {
+        DogSize.SMALL -> ProtoDogSize.DOG_SIZE_SMALL
+        DogSize.MEDIUM -> ProtoDogSize.DOG_SIZE_MEDIUM
+        DogSize.LARGE -> ProtoDogSize.DOG_SIZE_LARGE
     }
 }

--- a/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/server/WalksGrpcService.kt
+++ b/services/walks/src/main/kotlin/com/mungcle/walks/infrastructure/grpc/server/WalksGrpcService.kt
@@ -21,6 +21,8 @@ import com.mungcle.proto.walks.v1.GetWalkRequest
 import com.mungcle.proto.walks.v1.StartWalkRequest
 import com.mungcle.proto.walks.v1.StopWalkRequest
 import com.mungcle.proto.walks.v1.WalkInfo
+import com.mungcle.proto.walks.v1.WalkStatus as ProtoWalkStatus
+import com.mungcle.proto.walks.v1.WalkType as ProtoWalkType
 import com.mungcle.proto.walks.v1.WalksServiceGrpcKt
 import com.mungcle.proto.walks.v1.getMyActiveWalksResponse
 import com.mungcle.proto.walks.v1.getNearbyPatternsResponse
@@ -30,6 +32,7 @@ import com.mungcle.proto.walks.v1.nearbyWalkInfo
 import com.mungcle.proto.walks.v1.walkInfo
 import com.mungcle.proto.walks.v1.walkPatternInfo
 import com.mungcle.walks.domain.model.Walk
+import com.mungcle.walks.domain.model.WalkStatus
 import io.grpc.Status
 import io.grpc.StatusException
 import net.devh.boot.grpc.server.service.GrpcService
@@ -47,8 +50,8 @@ class WalksGrpcService(
 
     override suspend fun startWalk(request: StartWalkRequest): WalkInfo {
         val walkType = when (request.type) {
-            com.mungcle.proto.walks.v1.WalkType.WALK_TYPE_OPEN -> WalkType.OPEN
-            com.mungcle.proto.walks.v1.WalkType.WALK_TYPE_SOLO -> WalkType.SOLO
+            ProtoWalkType.WALK_TYPE_OPEN -> WalkType.OPEN
+            ProtoWalkType.WALK_TYPE_SOLO -> WalkType.SOLO
             else -> throw StatusException(
                 Status.INVALID_ARGUMENT.withDescription("유효하지 않은 산책 타입입니다")
             )
@@ -163,13 +166,13 @@ class WalksGrpcService(
         dogId = this@toWalkInfo.dogId
         userId = this@toWalkInfo.userId
         type = when (this@toWalkInfo.type) {
-            WalkType.OPEN -> com.mungcle.proto.walks.v1.WalkType.WALK_TYPE_OPEN
-            WalkType.SOLO -> com.mungcle.proto.walks.v1.WalkType.WALK_TYPE_SOLO
+            WalkType.OPEN -> ProtoWalkType.WALK_TYPE_OPEN
+            WalkType.SOLO -> ProtoWalkType.WALK_TYPE_SOLO
         }
         gridCell = this@toWalkInfo.gridCell.value
         status = when (this@toWalkInfo.status) {
-            com.mungcle.walks.domain.model.WalkStatus.ACTIVE -> com.mungcle.proto.walks.v1.WalkStatus.WALK_STATUS_ACTIVE
-            com.mungcle.walks.domain.model.WalkStatus.ENDED -> com.mungcle.proto.walks.v1.WalkStatus.WALK_STATUS_ENDED
+            WalkStatus.ACTIVE -> ProtoWalkStatus.WALK_STATUS_ACTIVE
+            WalkStatus.ENDED -> ProtoWalkStatus.WALK_STATUS_ENDED
         }
         startedAt = this@toWalkInfo.startedAt.epochSecond
         endsAt = this@toWalkInfo.endsAt.epochSecond


### PR DESCRIPTION
## Summary
- gRPC 서비스 4개에서 proto enum을 풀 패키지 경로(`com.mungcle.proto.*.v1.EnumName`)로 참조하던 것을 `import as Proto*` alias로 변경
- 대상: `IdentityAuthGrpcService`, `NotificationGrpcService`, `WalksGrpcService`, `PetProfileGrpcService`
- 도메인 모델과 proto enum 이름 충돌 시 `ProtoSocialProvider`, `ProtoNotificationType`, `ProtoWalkType`, `ProtoWalkStatus`, `ProtoDogSize` alias 사용

## Notion
- [MC-56](https://www.notion.so/gRPC-import-alias-34cbbf1e57438114b3d6d842ebebdd2a)

## Test plan
- [x] `./gradlew :services:identity:test` 통과
- [x] `./gradlew :services:notification:test` 통과
- [x] `./gradlew :services:walks:test` 통과
- [x] `./gradlew :services:pet-profile:compileKotlin` 통과 (기존 중복 파일 제외 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)