### PR TITLE
feat(app): 웹 프론트엔드 반응형 레이아웃 대응

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -1,7 +1,9 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { colors } from '../../src/constants/theme';
+import { useResponsive } from '../../src/shared/hooks/useResponsive';
+import { WebSidebar } from '../../src/shared/components/WebSidebar';
 
 function TabIcon({ icon, focused }: { icon: string; focused: boolean }) {
   return (
@@ -10,17 +12,22 @@ function TabIcon({ icon, focused }: { icon: string; focused: boolean }) {
 }
 
 export default function TabsLayout() {
-  return (
+  const { showSidebar } = useResponsive();
+
+  const tabs = (
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.textMuted,
-        tabBarStyle: {
-          backgroundColor: colors.surface,
-          borderTopColor: colors.border,
-        },
+        tabBarStyle: showSidebar
+          ? { display: 'none' }
+          : {
+              backgroundColor: colors.surface,
+              borderTopColor: colors.border,
+            },
         headerStyle: { backgroundColor: colors.background },
         headerTintColor: colors.text,
+        headerShown: !showSidebar,
       }}
     >
       <Tabs.Screen
@@ -53,4 +60,23 @@ export default function TabsLayout() {
       />
     </Tabs>
   );
+
+  if (!showSidebar) return tabs;
+
+  return (
+    <View style={styles.webLayout}>
+      <WebSidebar />
+      <View style={styles.webContent}>{tabs}</View>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  webLayout: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  webContent: {
+    flex: 1,
+  },
+});

--- a/frontend/app/(tabs)/dogs.tsx
+++ b/frontend/app/(tabs)/dogs.tsx
@@ -9,6 +9,7 @@ import type { Dog } from '../../src/features/dogs/types/dogs.types';
 import { getMyDogs } from '../../src/features/dogs';
 import { useApi } from '../../src/shared/hooks/useApi';
 import { EmptyState } from '../../src/shared/components/EmptyState';
+import { ResponsiveContainer } from '../../src/shared/components/ResponsiveContainer';
 
 const MAX_DOGS = 5;
 
@@ -98,23 +99,25 @@ export default function DogsScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <FlatList
-        data={dogList}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        ListHeaderComponent={ListHeader}
-        ListFooterComponent={ListFooter}
-        ListEmptyComponent={
-          <EmptyState
-            icon="🐶"
-            message="등록된 강아지가 없어요."
-            ctaLabel="강아지 추가하기"
-            onCta={handleAdd}
-          />
-        }
-        contentContainerStyle={styles.list}
-        showsVerticalScrollIndicator={false}
-      />
+      <ResponsiveContainer>
+        <FlatList
+          data={dogList}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          ListHeaderComponent={ListHeader}
+          ListFooterComponent={ListFooter}
+          ListEmptyComponent={
+            <EmptyState
+              icon="🐶"
+              message="등록된 강아지가 없어요."
+              ctaLabel="강아지 추가하기"
+              onCta={handleAdd}
+            />
+          }
+          contentContainerStyle={styles.list}
+          showsVerticalScrollIndicator={false}
+        />
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -13,6 +13,8 @@ import { TimePatternCard } from '../../src/features/walks/components/TimePattern
 import { WalkToggle } from '../../src/features/walks/components/WalkToggle';
 import { useNearbyWalks } from '../../src/features/walks/hooks/useNearbyWalks';
 import { EmptyState } from '../../src/shared/components/EmptyState';
+import { ResponsiveContainer } from '../../src/shared/components/ResponsiveContainer';
+import { useResponsive } from '../../src/shared/hooks/useResponsive';
 import type { NearbyWalkCard } from '../../src/features/walks/types/walks.types';
 
 // 스켈레톤 카드 — 로딩 대체 UI
@@ -152,15 +154,18 @@ export default function HomeScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <FlatList
-        data={walks}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        ListHeaderComponent={ListHeader}
-        ListEmptyComponent={ListEmpty}
-        contentContainerStyle={styles.list}
-        showsVerticalScrollIndicator={false}
-      />
+      <ResponsiveContainer>
+        <FlatList
+          data={walks}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          ListHeaderComponent={ListHeader}
+          ListEmptyComponent={ListEmpty}
+          contentContainerStyle={styles.list}
+          showsVerticalScrollIndicator={false}
+          numColumns={1}
+        />
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/frontend/app/(tabs)/notifications.tsx
+++ b/frontend/app/(tabs)/notifications.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { colors, spacing } from '../../src/constants/theme';
 import { typography } from '../../src/constants/typography';
 import { NotificationList, useNotifications } from '../../src/features/notifications';
+import { ResponsiveContainer } from '../../src/shared/components/ResponsiveContainer';
 
 export default function NotificationsScreen() {
   const {
@@ -23,26 +24,28 @@ export default function NotificationsScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <View style={styles.header}>
-        <Text style={styles.title}>알림</Text>
-        <TouchableOpacity
-          style={styles.markAllButton}
-          onPress={handleMarkAllRead}
-          accessibilityLabel="모두 읽음 처리"
-          accessibilityRole="button"
-        >
-          <Text style={styles.markAllText}>모두 읽음</Text>
-        </TouchableOpacity>
-      </View>
-      <NotificationList
-        notifications={notifications}
-        loading={loading}
-        error={error ? error.message : null}
-        hasMore={hasMore}
-        onRefresh={refresh}
-        onLoadMore={loadMore}
-        onMarkRead={handleMarkRead}
-      />
+      <ResponsiveContainer maxWidth={720}>
+        <View style={styles.header}>
+          <Text style={styles.title}>알림</Text>
+          <TouchableOpacity
+            style={styles.markAllButton}
+            onPress={handleMarkAllRead}
+            accessibilityLabel="모두 읽음 처리"
+            accessibilityRole="button"
+          >
+            <Text style={styles.markAllText}>모두 읽음</Text>
+          </TouchableOpacity>
+        </View>
+        <NotificationList
+          notifications={notifications}
+          loading={loading}
+          error={error ? error.message : null}
+          hasMore={hasMore}
+          onRefresh={refresh}
+          onLoadMore={loadMore}
+          onMarkRead={handleMarkRead}
+        />
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/frontend/app/(tabs)/settings.tsx
+++ b/frontend/app/(tabs)/settings.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '../../src/features/auth';
 import { deleteAccount } from '../../src/features/settings';
 import { colors, spacing, borderRadius, touchTarget } from '../../src/constants/theme';
 import { typography } from '../../src/constants/typography';
+import { ResponsiveContainer } from '../../src/shared/components/ResponsiveContainer';
 
 interface MenuItemProps {
   label: string;
@@ -62,6 +63,7 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
+      <ResponsiveContainer maxWidth={640}>
       <View style={styles.content}>
         <Text style={styles.title}>설정</Text>
 
@@ -117,6 +119,7 @@ export default function SettingsScreen() {
           />
         </View>
       </View>
+      </ResponsiveContainer>
 
       {/* 회원 탈퇴 확인 모달 */}
       <Modal

--- a/frontend/src/shared/components/ResponsiveContainer.tsx
+++ b/frontend/src/shared/components/ResponsiveContainer.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { StyleSheet, View, type ViewStyle } from 'react-native';
+import { useResponsive } from '../hooks/useResponsive';
+
+interface Props {
+  children: React.ReactNode;
+  maxWidth?: number;
+  style?: ViewStyle;
+}
+
+export function ResponsiveContainer({ children, maxWidth = 960, style }: Props) {
+  const { isWeb } = useResponsive();
+
+  if (!isWeb) {
+    return <View style={[styles.base, style]}>{children}</View>;
+  }
+
+  return (
+    <View style={[styles.base, styles.webContainer, { maxWidth }, style]}>
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    flex: 1,
+  },
+  webContainer: {
+    width: '100%' as unknown as number,
+    alignSelf: 'center',
+  },
+});

--- a/frontend/src/shared/components/WebSidebar.tsx
+++ b/frontend/src/shared/components/WebSidebar.tsx
@@ -1,0 +1,96 @@
+import { usePathname, useRouter } from 'expo-router';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors, spacing } from '../../constants/theme';
+import { typography } from '../../constants/typography';
+
+interface NavItem {
+  icon: string;
+  label: string;
+  path: string;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { icon: '🏠', label: '홈', path: '/(tabs)' },
+  { icon: '🐾', label: '내 강아지', path: '/(tabs)/dogs' },
+  { icon: '🔔', label: '알림', path: '/(tabs)/notifications' },
+  { icon: '⚙️', label: '설정', path: '/(tabs)/settings' },
+];
+
+export function WebSidebar() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const isActive = (path: string) => {
+    if (path === '/(tabs)') return pathname === '/' || pathname === '/(tabs)';
+    return pathname.startsWith(path.replace('/(tabs)', ''));
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.logo}>멍클</Text>
+
+      <View style={styles.nav}>
+        {NAV_ITEMS.map((item) => {
+          const active = isActive(item.path);
+          return (
+            <Pressable
+              key={item.path}
+              style={[styles.navItem, active && styles.navItemActive]}
+              onPress={() => router.push(item.path as Parameters<typeof router.push>[0])}
+              accessibilityLabel={item.label}
+              accessibilityRole="link"
+            >
+              <Text style={styles.navIcon}>{item.icon}</Text>
+              <Text style={[styles.navLabel, active && styles.navLabelActive]}>
+                {item.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: 240,
+    backgroundColor: colors.surface,
+    borderRightWidth: 1,
+    borderRightColor: colors.border,
+    paddingTop: spacing.xl,
+    paddingHorizontal: spacing.md,
+  },
+  logo: {
+    ...typography.display,
+    color: colors.primary,
+    paddingHorizontal: spacing.sm,
+    marginBottom: spacing.xl,
+  },
+  nav: {
+    gap: spacing.xs,
+  },
+  navItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.sm + 4,
+    paddingHorizontal: spacing.md,
+    borderRadius: 8,
+  },
+  navItemActive: {
+    backgroundColor: `${colors.primary}14`,
+  },
+  navIcon: {
+    fontSize: 20,
+  },
+  navLabel: {
+    ...typography.body,
+    color: colors.textMuted,
+  },
+  navLabelActive: {
+    color: colors.primary,
+    fontWeight: '600',
+  },
+});

--- a/frontend/src/shared/hooks/useResponsive.ts
+++ b/frontend/src/shared/hooks/useResponsive.ts
@@ -1,0 +1,30 @@
+import { useWindowDimensions, Platform } from 'react-native';
+
+export type Breakpoint = 'mobile' | 'tablet' | 'desktop';
+
+const BREAKPOINTS = {
+  tablet: 768,
+  desktop: 1024,
+} as const;
+
+export function useResponsive() {
+  const { width } = useWindowDimensions();
+
+  const breakpoint: Breakpoint =
+    width >= BREAKPOINTS.desktop
+      ? 'desktop'
+      : width >= BREAKPOINTS.tablet
+        ? 'tablet'
+        : 'mobile';
+
+  return {
+    breakpoint,
+    isMobile: breakpoint === 'mobile',
+    isTablet: breakpoint === 'tablet',
+    isDesktop: breakpoint === 'desktop',
+    isWeb: Platform.OS === 'web',
+    showSidebar: Platform.OS === 'web' && width >= BREAKPOINTS.tablet,
+    contentColumns: breakpoint === 'desktop' ? 3 : breakpoint === 'tablet' ? 2 : 1,
+    width,
+  };
+}


### PR DESCRIPTION
## Summary
- `useResponsive` 훅으로 mobile/tablet/desktop 브레이크포인트 감지
- 웹 태블릿 이상에서 좌측 `WebSidebar` + 하단 탭 숨김 전환
- `ResponsiveContainer`로 콘텐츠 영역 max-width 제한 (홈 960px, 알림 720px, 설정 640px)
- 모바일은 기존 하단 탭 그대로 유지 (변경 없음)

## Notion
- [MC-59](https://www.notion.so/34cbbf1e5743811fa9c9ce7b3782dc35)

## Test plan
- [x] `npx expo export --platform web` 웹 빌드 성공
- [x] `npx jest` 75개 테스트 전부 통과
- [ ] 웹 브라우저에서 사이드바/탭 전환 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)